### PR TITLE
Move start session

### DIFF
--- a/app/src/main/java/tech/ula/ui/ServerService.kt
+++ b/app/src/main/java/tech/ula/ui/ServerService.kt
@@ -140,6 +140,7 @@ class ServerService : Service() {
 
                 while (downloadList.size != downloadedList.size) {
                     updateProgressBar(getString(R.string.progress_downloading),getString(R.string.progress_downloading_out_of,downloadedList.size,downloadList.size))
+                    delay(500)
                 }
                 if (assetsWereDownloaded) {
                     fileManager.moveDownloadedAssetsToSharedSupportDirectory()

--- a/app/src/main/java/tech/ula/ui/ServerService.kt
+++ b/app/src/main/java/tech/ula/ui/ServerService.kt
@@ -32,8 +32,7 @@ class ServerService : Service() {
     private val downloadBroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             val downloadedId = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
-            if (downloadedId != null)
-                downloadedList.add(downloadedId)
+            downloadedId?.let { downloadedList.add(it) }
         }
     }
 

--- a/app/src/main/java/tech/ula/ui/ServerService.kt
+++ b/app/src/main/java/tech/ula/ui/ServerService.kt
@@ -1,15 +1,81 @@
 package tech.ula.ui
 
+import android.app.DownloadManager
 import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ActivityInfo
+import android.net.wifi.WifiManager
 import android.os.IBinder
-import tech.ula.utils.NotificationUtility
+import android.support.v4.content.LocalBroadcastManager
+import android.view.View
+import android.view.animation.AlphaAnimation
+import kotlinx.android.synthetic.main.activity_session_list.*
+import kotlinx.coroutines.experimental.delay
+import tech.ula.R
+import tech.ula.model.entities.Filesystem
+import tech.ula.model.entities.Session
+import tech.ula.utils.*
 
 class ServerService : Service() {
+
+    companion object {
+        val SERVER_SERVICE_RESULT = "tech.ula.ServerService.RESULT"
+    }
+
     private val activeSessions: ArrayList<Long> = ArrayList()
+
+    private lateinit var broadcaster: LocalBroadcastManager
+
+
+    private val downloadList = ArrayList<Long>()
+
+    private val downloadedList = ArrayList<Long>()
+
+    private val downloadBroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val downloadedId = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
+            if (downloadedId != null)
+                downloadedList.add(downloadedId)
+        }
+    }
 
     private val notificationManager: NotificationUtility by lazy {
         NotificationUtility(this)
+    }
+
+    private val filesystemUtility by lazy {
+        FilesystemUtility(this)
+    }
+
+    private val fileManager by lazy {
+        FileUtility(this)
+    }
+
+
+    private val serverUtility by lazy {
+        ServerUtility(this)
+    }
+
+    private val clientUtility by lazy {
+        ClientUtility(this)
+    }
+
+    private val FILESYSTEM_EXTRACT_LOGGER = { line: String -> Int
+        updateProgressBar(getString(R.string.progress_setting_up),getString(R.string.progress_setting_up_extract_text,line))
+        0
+    }
+
+    override fun onCreate() {
+        broadcaster = LocalBroadcastManager.getInstance(this)
+        registerReceiver(downloadBroadcastReceiver, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
+    }
+
+    override fun onDestroy() {
+        unregisterReceiver(downloadBroadcastReceiver)
+        super.onDestroy()
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -20,12 +86,10 @@ class ServerService : Service() {
         super.onStartCommand(intent, flags, startId)
 
         val intentType = intent.getStringExtra("type")
-        val pid = intent.getLongExtra("pid", -1)
-        if(pid != (-1).toLong()) {
-            when (intentType) {
-                "start" -> startSession(pid)
-                "kill" -> killSession(pid)
-            }
+        when (intentType) {
+            "start" -> startSession(intent)
+            "continue" -> continueStartSession(intent)
+            "kill" -> killSession(intent)
         }
         return Service.START_STICKY
     }
@@ -38,16 +102,128 @@ class ServerService : Service() {
         stopSelf()
     }
 
-    private fun startSession(pid: Long) {
+    private fun addSession(pid: Long) {
         activeSessions.add(pid)
         startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
     }
 
-    private fun killSession(pid: Long) {
+    private fun removeSession(pid: Long) {
         activeSessions.remove(pid)
         if(activeSessions.isEmpty()) {
             stopForeground(true)
             stopSelf()
         }
     }
+
+    private fun killSession(intent: Intent) {
+        val session = intent.getParcelableExtra<Session>("session")
+        serverUtility.stopService(session)
+        removeSession(session.pid)
+        session.active = false
+        updateSession(session)
+
+    }
+
+    private fun continueStartSession(intent: Intent) {
+        var session = intent.getParcelableExtra<Session>("session")
+        val filesystem = intent.getParcelableExtra<Filesystem>("filesystem")
+        val archType = filesystemUtility.getArchType()
+        val distType = filesystem!!.distributionType
+        val downloadManager = DownloadUtility(this@ServerService, archType, distType)
+        var assetsWereDownloaded = false
+        val filesystemDirectoryName = session.filesystemId.toString()
+        launchAsync {
+            startProgressBar()
+            updateProgressBar(getString(R.string.progress_downloading),"")
+            asyncAwait {
+                downloadList.clear()
+                downloadedList.clear()
+                downloadList.addAll(downloadManager.downloadRequirements())
+
+                if (downloadList.isNotEmpty())
+                    assetsWereDownloaded = true
+
+                while (downloadList.size != downloadedList.size) {
+                    updateProgressBar(getString(R.string.progress_downloading),getString(R.string.progress_downloading_out_of,downloadedList.size,downloadList.size))
+                }
+                if (assetsWereDownloaded) {
+                    fileManager.moveDownloadedAssetsToSharedSupportDirectory()
+                    fileManager.correctFilePermissions()
+                }
+            }
+            updateProgressBar(getString(R.string.progress_setting_up),"")
+            asyncAwait {
+                // TODO only copy when newer versions have been downloaded (and skip rootfs)
+                fileManager.copyDistributionAssetsToFilesystem(filesystemDirectoryName, distType)
+                if (!fileManager.statusFileExists(filesystemDirectoryName, ".success_filesystem_extraction")) {
+                    filesystemUtility.extractFilesystem(filesystemDirectoryName,FILESYSTEM_EXTRACT_LOGGER)
+                }
+            }
+            updateProgressBar(getString(R.string.progress_starting),"")
+            asyncAwait {
+
+                session.pid = serverUtility.startServer(session)
+                addSession(session.pid)
+
+                while (!serverUtility.isServerRunning(session)) {
+                    delay(500)
+                }
+            }
+            asyncAwait {
+                clientUtility.startClient(session)
+            }
+            session.active = true
+            updateSession(session)
+
+            killProgressBar()
+        }
+    }
+
+    private fun startSession(intent: Intent) {
+        var session = intent.getParcelableExtra<Session>("session")
+        val filesystem = intent.getParcelableExtra<Filesystem>("filesystem")
+        val archType = filesystemUtility.getArchType()
+        val distType = filesystem!!.distributionType
+        val downloadManager = DownloadUtility(this@ServerService, archType, distType)
+        if (downloadManager.checkIfLargeRequirement()) {
+            displayWifiChoices(session)
+        } else {
+            continueStartSession(intent)
+        }
+    }
+
+    private fun startProgressBar() {
+        val intent = Intent(SERVER_SERVICE_RESULT)
+        intent.putExtra("type", "startProgressBar")
+        broadcaster.sendBroadcast(intent)
+    }
+
+    private fun killProgressBar() {
+        val intent = Intent(SERVER_SERVICE_RESULT)
+        intent.putExtra("type", "killProgressBar")
+        broadcaster.sendBroadcast(intent)
+    }
+
+    private fun updateProgressBar(step: String, details: String) {
+        val intent = Intent(SERVER_SERVICE_RESULT)
+        intent.putExtra("type", "updateProgressBar")
+        intent.putExtra("step", step)
+        intent.putExtra("details", details)
+        broadcaster.sendBroadcast(intent)
+    }
+
+    private fun updateSession(session: Session) {
+        val intent = Intent(SERVER_SERVICE_RESULT)
+        intent.putExtra("type", "updateSession")
+        intent.putExtra("session", session)
+        broadcaster.sendBroadcast(intent)
+    }
+
+    private fun displayWifiChoices(session: Session) {
+        val intent = Intent(SERVER_SERVICE_RESULT)
+        intent.putExtra("type", "displayWifiChoices")
+        intent.putExtra("session", session)
+        broadcaster.sendBroadcast(intent)
+    }
+
 }

--- a/app/src/main/java/tech/ula/ui/ServerService.kt
+++ b/app/src/main/java/tech/ula/ui/ServerService.kt
@@ -6,13 +6,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.ActivityInfo
-import android.net.wifi.WifiManager
 import android.os.IBinder
 import android.support.v4.content.LocalBroadcastManager
-import android.view.View
-import android.view.animation.AlphaAnimation
-import kotlinx.android.synthetic.main.activity_session_list.*
 import kotlinx.coroutines.experimental.delay
 import tech.ula.R
 import tech.ula.model.entities.Filesystem

--- a/app/src/main/java/tech/ula/ui/SessionListActivity.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListActivity.kt
@@ -2,7 +2,6 @@ package tech.ula.ui
 
 import android.Manifest
 import android.app.AlertDialog
-import android.app.DownloadManager
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.BroadcastReceiver
@@ -17,6 +16,7 @@ import android.os.Bundle
 import android.preference.PreferenceManager
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
+import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
 import android.view.ContextMenu
 import android.view.Menu
@@ -25,8 +25,6 @@ import android.view.View
 import android.view.animation.AlphaAnimation
 import android.widget.AdapterView
 import kotlinx.android.synthetic.main.activity_session_list.*
-import kotlinx.android.synthetic.main.list_item_session.view.*
-import kotlinx.coroutines.experimental.*
 import org.jetbrains.anko.longToast
 import tech.ula.BuildConfig
 import tech.ula.R
@@ -67,29 +65,29 @@ class SessionListActivity : AppCompatActivity() {
         }
     }
 
-    private val downloadList = ArrayList<Long>()
-
-    private val downloadedList = ArrayList<Long>()
-
-    private val downloadBroadcastReceiver = object : BroadcastReceiver() {
+    private val serverServiceBroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            val downloadedId = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
-            if (downloadedId != null)
-                downloadedList.add(downloadedId)
+            this@SessionListActivity.runOnUiThread({
+                if (intent != null) {
+                    val type = intent.getStringExtra("type")
+                    when (type) {
+                        "startProgressBar" -> startProgressBar()
+                        "updateProgressBar" -> updateProgressBar(intent)
+                        "killProgressBar" -> killProgressBar()
+                        "updateSession" -> updateSession(intent)
+                        "displayWifiChoices" -> displayWifiChoices(intent)
+                    }
+                }
+            })
         }
-    }
-
-    private val FILESYSTEM_EXTRACT_LOGGER = { line: String -> Int
-        this.runOnUiThread({text_session_list_progress_details.text = getString(R.string.progress_setting_up_extract_text,line)})
-        0
-    }
-
-    private val fileManager by lazy {
-        FileUtility(this)
     }
 
     private val notificationManager by lazy {
         NotificationUtility(this)
+    }
+
+    private val filesystemUtility by lazy {
+        FilesystemUtility(this)
     }
 
     private val serverUtility by lazy {
@@ -98,10 +96,6 @@ class SessionListActivity : AppCompatActivity() {
 
     private val clientUtility by lazy {
         ClientUtility(this)
-    }
-
-    private val filesystemUtility by lazy {
-        FilesystemUtility(this)
     }
 
     private val permissionRequestCode = 1000
@@ -130,7 +124,7 @@ class SessionListActivity : AppCompatActivity() {
 
         registerForContextMenu(list_sessions)
         list_sessions.onItemClickListener = AdapterView.OnItemClickListener {
-            _, view, position, _ ->
+            _, _, position, _ ->
             if(!arePermissionsGranted()) {
                 showPermissionsNecessaryDialog()
                 return@OnItemClickListener
@@ -139,7 +133,7 @@ class SessionListActivity : AppCompatActivity() {
             val session = sessionList[position]
             if(!session.active) {
                 if (!activeSessions) {
-                    startSession(session, view)
+                    startSession(session)
                 } else {
                     longToast(R.string.single_session_supported)
                 }
@@ -150,11 +144,19 @@ class SessionListActivity : AppCompatActivity() {
 
         }
 
-        registerReceiver(downloadBroadcastReceiver, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
-
         fab.setOnClickListener { navigateToSessionEdit(Session(0, filesystemId = 0)) }
 
         progress_bar_session_list.visibility = View.VISIBLE
+    }
+
+    override fun onStart() {
+        super.onStart()
+        LocalBroadcastManager.getInstance(this).registerReceiver(serverServiceBroadcastReceiver, IntentFilter(ServerService.SERVER_SERVICE_RESULT))
+    }
+
+    override fun onStop() {
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(serverServiceBroadcastReceiver)
+        super.onStop()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
@@ -196,7 +198,7 @@ class SessionListActivity : AppCompatActivity() {
         val position = menuInfo.position
         val session = sessionList[position]
         return when(item.itemId) {
-            R.id.menu_item_session_kill_service -> stopService(session)
+            R.id.menu_item_session_kill_service -> killSession(session)
             R.id.menu_item_session_edit -> navigateToSessionEdit(session)
             R.id.menu_item_session_delete -> deleteSession(session)
             else -> super.onContextItemSelected(item)
@@ -237,28 +239,9 @@ class SessionListActivity : AppCompatActivity() {
         builder.create().show()
     }
 
-    fun stopService(session: Session): Boolean {
-        // TODO update all sessions relying on service
-        // TODO more granular service killing
-        if(session.active) {
-            session.active = false
-            sessionListViewModel.updateSession(session)
-            val view = list_sessions.getChildAt(sessionList.indexOf(session))
-            view.image_list_item_active.setImageResource(R.drawable.ic_block_red_24dp)
 
-            serverUtility.stopService(session)
-
-            val serviceIntent = Intent(this, ServerService::class.java)
-            serviceIntent.putExtra("type", "kill")
-            serviceIntent.putExtra("pid", session.pid)
-
-            startService(serviceIntent)
-        }
-        return true
-    }
-
-    fun deleteSession(session: Session): Boolean {
-        stopService(session)
+    private fun deleteSession(session: Session): Boolean {
+        killSession(session)
         sessionListViewModel.deleteSessionById(session.id)
         return true
     }
@@ -289,100 +272,83 @@ class SessionListActivity : AppCompatActivity() {
         return true
     }
 
-    private fun startSession(session: Session, view: View) {
-        val filesystemDirectoryName = session.filesystemId.toString()
-        var assetsWereDownloaded = false
-        launchAsync {
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
-
-            val inAnimation = AlphaAnimation(0f, 1f)
-            inAnimation.duration = 200
-            layout_progress.animation = inAnimation
-            layout_progress.visibility = View.VISIBLE
-
-            val archType = filesystemUtility.getArchType()
-            val filesystem = filesystemList.find { it.name == session.filesystemName }
-            val distType = filesystem!!.distributionType
-            val downloadManager = DownloadUtility(this@SessionListActivity, archType, distType)
-            if (downloadManager.checkIfLargeRequirement()) {
-                val result = downloadManager.displayWifiChoices()
-                when (result) {
-                    DownloadUtility.TURN_ON_WIFI -> {
-                        startActivity(Intent(WifiManager.ACTION_PICK_WIFI_NETWORK))
-                        endProgressBar()
-                        return@launchAsync
-                    }
-                    DownloadUtility.CANCEL -> {
-                        endProgressBar()
-                        return@launchAsync
-                    }
-
-                }
-            }
-
-            text_session_list_progress_step.setText(R.string.progress_downloading)
-            text_session_list_progress_details.text = ""
-            asyncAwait {
-                downloadList.clear()
-                downloadedList.clear()
-                downloadList.addAll(downloadManager.downloadRequirements())
-
-                if (downloadList.isNotEmpty())
-                    assetsWereDownloaded = true
-
-                while (downloadList.size != downloadedList.size) {
-                    this@SessionListActivity.runOnUiThread({text_session_list_progress_details.text = getString(R.string.progress_downloading_out_of,downloadedList.size,downloadList.size)})
-                    delay(500)
-                }
-                if (assetsWereDownloaded) {
-                    fileManager.moveDownloadedAssetsToSharedSupportDirectory()
-                    fileManager.correctFilePermissions()
-                }
-            }
-            text_session_list_progress_details.text = ""
-
-            text_session_list_progress_step.setText(R.string.progress_setting_up)
-            asyncAwait {
-                // TODO only copy when newer versions have been downloaded (and skip rootfs)
-                fileManager.copyDistributionAssetsToFilesystem(filesystemDirectoryName, distType)
-                if (!fileManager.statusFileExists(filesystemDirectoryName, ".success_filesystem_extraction")) {
-                    filesystemUtility.extractFilesystem(filesystemDirectoryName,FILESYSTEM_EXTRACT_LOGGER)
-                }
-            }
-
-            text_session_list_progress_step.setText(R.string.progress_starting)
-            text_session_list_progress_details.text = ""
-            asyncAwait {
-
-                session.pid = serverUtility.startServer(session)
-
-                val serviceIntent = Intent(this@SessionListActivity, ServerService::class.java)
-                serviceIntent.putExtra("type", "start")
-                serviceIntent.putExtra("pid", session.pid)
-                startService(serviceIntent)
-
-                while (!serverUtility.isServerRunning(session)) {
-                    delay(500)
-                }
-            }
-
-            text_session_list_progress_step.setText(R.string.progress_connecting)
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
-            asyncAwait {
-                clientUtility.startClient(session)
-            }
-
-            session.active = true
-            sessionListViewModel.updateSession(session)
-
-            endProgressBar()
-        }
+    private fun startSession(session: Session) {
+        val filesystem = filesystemList.find { it.name == session.filesystemName }
+        val serviceIntent = Intent(this@SessionListActivity, ServerService::class.java)
+        serviceIntent.putExtra("session", session)
+        serviceIntent.putExtra("filesystem", filesystem)
+        serviceIntent.putExtra("type", "start")
+        startService(serviceIntent)
     }
 
-    private fun endProgressBar() {
+    private fun continueStartSession(session: Session) {
+        val filesystem = filesystemList.find { it.name == session.filesystemName }
+        val serviceIntent = Intent(this@SessionListActivity, ServerService::class.java)
+        serviceIntent.putExtra("continue", session)
+        serviceIntent.putExtra("filesystem", filesystem)
+        serviceIntent.putExtra("type", "start")
+        startService(serviceIntent)
+    }
+
+    private fun killSession(session: Session): Boolean {
+        if(session.active) {
+            val serviceIntent = Intent(this@SessionListActivity, ServerService::class.java)
+            serviceIntent.putExtra("session", session)
+            serviceIntent.putExtra("type", "kill")
+            startService(serviceIntent)
+        }
+        return true
+    }
+
+    private fun startProgressBar() {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
+        val inAnimation = AlphaAnimation(0f, 1f)
+        inAnimation.duration = 200
+        layout_progress.animation = inAnimation
+        layout_progress.visibility = View.VISIBLE
+    }
+
+    private fun killProgressBar() {
         val outAnimation = AlphaAnimation(1f, 0f)
         outAnimation.duration = 200
         layout_progress.animation = outAnimation
         layout_progress.visibility = View.GONE
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
     }
+
+    private fun updateProgressBar(intent: Intent) {
+        val step = intent.getStringExtra("step")
+        val details = intent.getStringExtra("details")
+        text_session_list_progress_step.text = step
+        text_session_list_progress_details.text = details
+    }
+
+    private fun updateSession(intent: Intent) {
+        val session = intent.getParcelableExtra<Session>("session")
+        sessionListViewModel.updateSession(session)
+    }
+
+    private fun displayWifiChoices(intent: Intent) {
+        var session = intent.getParcelableExtra<Session>("session")
+        val filesystem = filesystemList.find { it.name == session.filesystemName }
+        val archType = filesystemUtility.getArchType()
+        val distType = filesystem!!.distributionType
+        val downloadManager = DownloadUtility(this@SessionListActivity, archType, distType)
+        launchAsync {
+            val result = downloadManager.displayWifiChoices()
+            when (result) {
+                DownloadUtility.TURN_ON_WIFI -> {
+                    startActivity(Intent(WifiManager.ACTION_PICK_WIFI_NETWORK))
+                    killProgressBar()
+                }
+                DownloadUtility.CANCEL -> {
+                    killProgressBar()
+                }
+                else -> {
+                    continueStartSession(session)
+                }
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -6,18 +6,16 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import android.net.Uri
-import android.net.wifi.WifiManager
 import android.os.Environment
-import android.util.Log
 import tech.ula.R
 import java.io.File
 import kotlin.coroutines.experimental.Continuation
 import kotlin.coroutines.experimental.suspendCoroutine
 
-class DownloadUtility(val uiContext: Context, val archType: String, val distType: String) {
+class DownloadUtility(val context: Context, val archType: String, val distType: String) {
 
     private val downloadManager: DownloadManager by lazy {
-        uiContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
     }
 
     companion object {
@@ -58,7 +56,7 @@ class DownloadUtility(val uiContext: Context, val archType: String, val distType
 
     suspend fun displayWifiChoices(): Int {
         lateinit var result: Continuation<Int>
-        val builder = AlertDialog.Builder(uiContext)
+        val builder = AlertDialog.Builder(context)
         builder.setMessage(R.string.alert_wifi_disabled_message)
                 .setTitle(R.string.alert_wifi_disabled_title)
                 .setPositiveButton(R.string.alert_wifi_disabled_force_button, {
@@ -100,7 +98,7 @@ class DownloadUtility(val uiContext: Context, val archType: String, val distType
 
     private fun assetNeedsToUpdated(type: String): Boolean {
         val (subdirectory, filename) = type.split(":")
-        val asset = File("${uiContext.filesDir.path}/$subdirectory/$filename")
+        val asset = File("${context.filesDir.path}/$subdirectory/$filename")
         // TODO more sophisticated version checking
         return !asset.exists()
     }
@@ -118,7 +116,7 @@ class DownloadUtility(val uiContext: Context, val archType: String, val distType
     }
 
     private fun isWifiEnabled(): Boolean {
-        val connectivityManager = uiContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE)
         return if (connectivityManager is ConnectivityManager) {
             val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
             networkInfo?.type == ConnectivityManager.TYPE_WIFI
@@ -126,7 +124,7 @@ class DownloadUtility(val uiContext: Context, val archType: String, val distType
     }
 
     private fun isNetworkAvailable(): Boolean {
-        val connectivityManager = uiContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE)
         return if (connectivityManager is ConnectivityManager) {
             val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
             networkInfo?.isConnected ?: false


### PR DESCRIPTION
This moves all of the non-ui updating pieces of SessionListActivity related to starting and stopping services out of there and into ServerService

This fixes the bug where the app would crash if it was in the background when startSession finished.  

There is still some refactoring we could do, but this is pretty good and allows @MatthewTighe to see this big change and merge it into the big change he is making