### PR TITLE
Fixed UI bug in Session Edit screen for filesystem text

### DIFF
--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -52,8 +52,10 @@ class SessionEditFragment : Fragment() {
             }
             val filesystemAdapter = ArrayAdapter(activityContext, android.R.layout.simple_spinner_dropdown_item, filesystemNameList)
             val filesystemNamePosition = filesystemAdapter.getPosition(session.filesystemName)
+            val usedPosition = if (filesystemNamePosition < 0) 0 else filesystemNamePosition
+
             spinner_filesystem_list.adapter = filesystemAdapter
-            spinner_filesystem_list.setSelection(filesystemNamePosition)
+            spinner_filesystem_list.setSelection(usedPosition)
         }
     }
 

--- a/app/src/main/res/layout/frag_session_edit.xml
+++ b/app/src/main/res/layout/frag_session_edit.xml
@@ -31,13 +31,10 @@
         android:id="@+id/text_filesystem"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:text="@string/prompt_filesystem"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintBaseline_toBaselineOf="@id/spinner_filesystem_list"
-        app:layout_constraintEnd_toStartOf="@id/spinner_filesystem_list"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_input_layout_session_name" />
+        app:layout_constraintBottom_toBottomOf="@id/spinner_filesystem_list"
+        app:layout_constraintTop_toTopOf="@id/spinner_filesystem_list"
+        app:layout_constraintStart_toStartOf="parent"/>
 
     <!-- TODO more robust way of styling correctly
     using margin start is likely not enough on larger screens, different localizations
@@ -46,7 +43,7 @@
         android:id="@+id/spinner_filesystem_list"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="24dp"
         android:layout_marginStart="16dp"
         android:spinnerMode="dropdown"
         app:layout_constraintEnd_toEndOf="parent"
@@ -58,24 +55,23 @@
         android:id="@+id/text_session_service_type"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:text="@string/prompt_service_type"
         app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintBaseline_toBaselineOf="@id/spinner_session_service_type"
-        app:layout_constraintTop_toBottomOf="@id/text_filesystem"
+        app:layout_constraintBottom_toBottomOf="@id/spinner_session_service_type"
+        app:layout_constraintTop_toTopOf="@id/spinner_session_service_type"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/spinner_session_service_type" />
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <Spinner
         android:id="@+id/spinner_session_service_type"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="24dp"
         android:spinnerMode="dropdown"
         android:entries="@array/supported_services"
-        app:layout_constraintEnd_toEndOf="parent"
+
         app:layout_constraintStart_toStartOf="@id/spinner_filesystem_list"
-        app:layout_constraintStart_toEndOf="@id/text_session_service_type"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/spinner_filesystem_list" />
 
     <!-- Client Type -->
@@ -83,23 +79,21 @@
         android:id="@+id/text_session_client_type"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
         android:text="@string/prompt_client_type"
         app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintBaseline_toBaselineOf="@id/spinner_session_client_type"
-        app:layout_constraintTop_toBottomOf="@id/text_session_service_type"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/spinner_session_client_type"/>
+        app:layout_constraintTop_toTopOf="@id/spinner_session_client_type"
+        app:layout_constraintBottom_toBottomOf="@id/spinner_session_client_type"/>
 
     <Spinner
         android:id="@+id/spinner_session_client_type"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="24dp"
         android:spinnerMode="dropdown"
+        android:entries="@array/supported_ssh_clients"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/spinner_session_service_type"
-        app:layout_constraintStart_toEndOf="@id/text_session_client_type"
         app:layout_constraintTop_toBottomOf="@id/spinner_session_service_type" />
 
     <!-- Username -->


### PR DESCRIPTION

**Describe the pull request**

In the filesystem edit screen, only the top half of the filesystem text was displaying or was cut off vertically.  

The problem was that the spinner was displaying the element that is in the -1th index.
Solution is to check if the index is -1, if it is, set it to zero.

Before
![screen shot 2018-07-24 at 4 25 23 pm](https://user-images.githubusercontent.com/11577853/43171282-30993966-8f5e-11e8-81be-f56ddd2c3769.png)


After
![screen shot 2018-07-24 at 4 24 31 pm](https://user-images.githubusercontent.com/11577853/43171252-1023c700-8f5e-11e8-9d40-e9f5ba6d4397.png)


