### PR TITLE
Don't use getRuntime.exec

### DIFF
--- a/app/src/main/java/tech/ula/utils/FileUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FileUtility.kt
@@ -80,7 +80,12 @@ class FileUtility(val context: Context) {
 
     private fun changePermission(filename: String, subdirectory: String) {
         val executionDirectory = createAndGetDirectory(subdirectory)
-        val commandToRun = arrayOf("chmod", "0777", filename)
-        Runtime.getRuntime().exec(commandToRun, arrayOf<String>(), executionDirectory)
+        val commandToRun = arrayListOf("chmod", "0777", filename)
+
+        val pb = ProcessBuilder(commandToRun)
+        pb.directory(executionDirectory)
+
+        val process = pb.start()
+        process.waitFor()
     }
 }


### PR DESCRIPTION
**Describe the pull request**

If you use `getRuntime().exec()` you must set back up all environment variables a device requires for running an executable.  For example, some devices have a custom `LD_PRELOAD` .   Using a `ProcessBuilder` keeps those environment variable as they were by default (you can modify them if desired)

**Link to relevant issues**
