### PR TITLE
Hotfixes

### DIFF
--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -69,6 +69,7 @@ class SessionListFragment : Fragment() {
                         "killProgressBar" -> killProgressBar()
                         "isProgressBarActive" -> syncProgressBarDisplayedWithService(it)
                         "networkUnavailable" -> displayNetworkUnavailableDialog()
+                        "assetListFailure" -> displayAssetListFailureDialog()
                         "displayNetworkChoices" -> displayNetworkChoicesDialog()
                     }
                 }
@@ -295,6 +296,18 @@ class SessionListFragment : Fragment() {
         builder.setMessage(R.string.alert_network_unavailable_message)
                 .setTitle(R.string.alert_network_unavailable_title)
                 .setPositiveButton(R.string.alert_network_unavailable_cancel_button) {
+                    dialog, _ ->
+                    dialog.dismiss()
+                }
+                .create()
+                .show()
+    }
+
+    private fun displayAssetListFailureDialog() {
+        val builder = AlertDialog.Builder(activityContext)
+        builder.setMessage(R.string.alert_asset_list_failure_message)
+                .setTitle(R.string.alert_asset_list_failure_title)
+                .setPositiveButton(R.string.alert_asset_list_failure_cancel_button) {
                     dialog, _ ->
                     dialog.dismiss()
                 }

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -83,6 +83,7 @@ interface ConnectionAccessor {
 }
 
 class ConnectionUtility : ConnectionAccessor {
+    @Throws(Exception::class)
     override fun getAssetListConnection(url: String): InputStream {
         val conn = URL(url).openConnection() as HttpURLConnection
         conn.requestMethod = "GET"

--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -8,6 +8,7 @@ import tech.ula.model.entities.Session
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
+import java.net.ConnectException
 import java.util.concurrent.TimeUnit
 
 class DownloadUtility(
@@ -137,14 +138,18 @@ class DownloadUtility(
         }
 
         val url = "https://github.com/CypherpunkArmory/UserLAnd-Assets-$repo/raw/$branch/assets/$scope/assets.txt"
-        val reader = BufferedReader(InputStreamReader(connectionUtility.getAssetListConnection(url)))
-        reader.forEachLine {
-            val (filename, timestampAsString) = it.split(" ")
-            if (filename == "assets.txt") return@forEachLine
-            val timestamp = timestampAsString.toLong()
-            assetList.add(filename to timestamp)
+        try {
+            val reader = BufferedReader(InputStreamReader(connectionUtility.getAssetListConnection(url)))
+            reader.forEachLine {
+                val (filename, timestampAsString) = it.split(" ")
+                if (filename == "assets.txt") return@forEachLine
+                val timestamp = timestampAsString.toLong()
+                assetList.add(filename to timestamp)
+            }
+            reader.close()
+            return assetList
+        } catch (err: ConnectException) {
+            throw object : Exception("Error getting asset list") {}
         }
-        reader.close()
-        return assetList
     }
 }

--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -8,7 +8,6 @@ import tech.ula.model.entities.Session
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
-import java.net.ConnectException
 import java.util.concurrent.TimeUnit
 
 class DownloadUtility(
@@ -148,7 +147,7 @@ class DownloadUtility(
             }
             reader.close()
             return assetList
-        } catch (err: ConnectException) {
+        } catch (err: Exception) {
             throw object : Exception("Error getting asset list") {}
         }
     }

--- a/app/src/main/java/tech/ula/utils/ServerUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ServerUtility.kt
@@ -2,6 +2,7 @@ package tech.ula.utils
 
 import tech.ula.model.entities.Session
 import java.io.File
+import java.io.FileNotFoundException
 
 class ServerUtility(private val execUtility: ExecUtility, private val fileUtility: FileUtility) {
 
@@ -72,9 +73,13 @@ class ServerUtility(private val execUtility: ExecUtility, private val fileUtilit
     fun isServerRunning(session: Session): Boolean {
         val targetDirectoryName = session.filesystemId.toString()
         val command = "../support/isServerInProcTree.sh ${session.pid()}"
-        val process = execUtility.wrapWithBusyboxAndExecute(targetDirectoryName, command)
-        if (process.exitValue() != 0) // isServerInProcTree returns a 1 if it did't find a server
+        try {
+            val process = execUtility.wrapWithBusyboxAndExecute(targetDirectoryName, command)
+            if (process.exitValue() != 0) // isServerInProcTree returns a 1 if it did't find a server
+                return false
+        } catch (err: FileNotFoundException) {
             return false
+        }
         return true
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,11 @@
     <string name="alert_network_unavailable_message">UserLAnd requires network availability to download required assets.</string>
     <string name="alert_network_unavailable_cancel_button">Cancel</string>
 
+    <!-- Asset list failure alert -->
+    <string name="alert_asset_list_failure_title">Could not retrieve asset lists.</string>
+    <string name="alert_asset_list_failure_message">Please try again shortly. Ensure you have network access!</string>
+    <string name="alert_asset_list_failure_cancel_button">Cancel</string>
+
     <!-- Wifi alert -->
     <string name="alert_wifi_disabled_title">No wifi!</string>
     <string name="alert_wifi_disabled_message">A large asset (~80mb) needs to be downloaded.</string>

--- a/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
@@ -158,6 +158,21 @@ class DownloadUtilityTest {
     }
 
     @Test
+    fun rethrowsExceptionCorrectlyIfAssetListCantBeRetrieved() {
+        val session = Session(0, filesystemId = 0)
+        val filesystem = Filesystem(0)
+        downloadUtility = initDownloadUtility(session, filesystem)
+
+        `when`(connectivityManager.activeNetworkInfo).thenReturn(networkInfo)
+        `when`(connectionUtility.getAssetListConnection(assetListUrl)).thenThrow(Exception::class.java)
+        try {
+            downloadUtility.downloadRequirements(updateIsBeingForced = false, assetListTypes = assetListTypes)
+        } catch (err: Exception) {
+            assertEquals("Error getting asset list", err.message)
+        }
+    }
+
+    @Test
     fun downloadsRequirementsWhenForced() {
         val session = Session(0, filesystemId = 0)
         val filesystem = Filesystem(0)

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -83,10 +83,9 @@ class FilesystemUtilityTest {
 
     @Test
     fun getsCorrectSupportedAbis() {
-        var archType = ""
 
         `when`(buildUtility.getSupportedAbis()).thenReturn(arrayOf("arm64-v8a"))
-        archType = filesystemUtility.getArchType()
+        var archType = filesystemUtility.getArchType()
         assertEquals("arm64", archType)
 
         `when`(buildUtility.getSupportedAbis()).thenReturn(arrayOf("armeabi-v7a"))

--- a/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
@@ -1,7 +1,7 @@
 package tech.ula.utils
 
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
**Describe the pull request**

Wraps asset list retrieval in try catch blocks and displays an alert if it fails.
Silently fails to check for running servers if the script isn't present. Without this, the script would be run while not present during initialization of the session list to determine if they were active or not.

**Link to relevant issues**
#140 