### PR TITLE
Add behavior to immediately start session as soon as permissions are accepted.

### DIFF
--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -39,6 +39,8 @@ class SessionListFragment : Fragment() {
     private lateinit var sessionAdapter: SessionListAdapter
     private lateinit var filesystemList: List<Filesystem>
 
+    private lateinit var lastSelectedSession: Session
+
     private val sessionListViewModel: SessionListViewModel by lazy {
         ViewModelProviders.of(this).get(SessionListViewModel::class.java)
     }
@@ -81,12 +83,16 @@ class SessionListFragment : Fragment() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         when (requestCode) {
             permissionRequestCode -> {
-                if (!(grantResults.isNotEmpty() &&
-                                grantResults[0] == PackageManager.PERMISSION_GRANTED &&
-                                grantResults[1] == PackageManager.PERMISSION_GRANTED)) {
+
+                val grantedPermissions = (grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED &&
+                        grantResults[1] == PackageManager.PERMISSION_GRANTED)
+
+                if (grantedPermissions) {
+                    handleSessionSelection(lastSelectedSession)
+                } else {
                     showPermissionsNecessaryDialog()
                 }
-                return
             }
         }
     }
@@ -121,20 +127,25 @@ class SessionListFragment : Fragment() {
         registerForContextMenu(list_sessions)
         list_sessions.onItemClickListener = AdapterView.OnItemClickListener {
             _, _, position, _ ->
-            if (!arePermissionsGranted()) {
+            lastSelectedSession = sessionList[position]
+
+            if (arePermissionsGranted()) {
+                handleSessionSelection(lastSelectedSession)
+            } else {
                 showPermissionsNecessaryDialog()
                 return@OnItemClickListener
             }
+        }
+    }
 
-            val session = sessionList[position]
-            if (!session.active) {
-                if (!sessionListViewModel.activeSessions) {
-                    startSession(session)
-                } else {
-                    Toast.makeText(activityContext, R.string.single_session_supported, Toast.LENGTH_LONG).show()
-                }
+    private fun handleSessionSelection(session: Session) {
+        if (session.active) {
+            restartRunningSession(session)
+        } else {
+            if (sessionListViewModel.activeSessions) {
+                Toast.makeText(activityContext, R.string.single_session_supported, Toast.LENGTH_LONG).show()
             } else {
-                restartRunningSession(session)
+                startSession(session)
             }
         }
     }
@@ -167,7 +178,7 @@ class SessionListFragment : Fragment() {
                 .setTitle(R.string.alert_permissions_necessary_title)
                 .setPositiveButton(R.string.alert_permissions_necessary_ok_button) {
                     dialog, _ ->
-                    ActivityCompat.requestPermissions(activityContext, arrayOf(
+                    requestPermissions(arrayOf(
                             Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE),
                             permissionRequestCode)
                     dialog.dismiss()


### PR DESCRIPTION
**Describe the pull request**

**Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.**


As part of a UX improvement, when the user grants permissions to the app by tapping the `Allow` button on the permissions prompt, the selected session will start immediately after the pop-up is dismissed.



![permissions demo 1](https://user-images.githubusercontent.com/11577853/43604001-76568c96-9649-11e8-90fb-7cc113345aff.gif)



Helpful Stackoverflow link: https://stackoverflow.com/questions/32714787/android-m-permissions-onrequestpermissionsresult-not-being-called

**Link to relevant issues**
