### PR TITLE
Filesystem Spinner on SessionEditFragment will update to newly created filesystem

### DIFF
--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -117,9 +117,9 @@ class SessionEditFragment : Fragment() {
                     else -> {
                         // TODO adapter to associate filesystem structure with list items?
                         val filesystem = filesystemList.find { it.name == filesystemName }
-                        filesystem?.run {
-                            setFilesystemForSessionTo(this)
-                            text_input_username.setText(this.defaultUsername)
+                        filesystem?.let {
+                            updateFilesystemDetailsForSession(it)
+                            text_input_username.setText(it.defaultUsername)
                         }
                     }
                 }
@@ -210,11 +210,11 @@ class SessionEditFragment : Fragment() {
     private fun getListDifferenceAndSetNewFilesystem(prevFilesystems: List<Filesystem>, currentFilesystems: List<Filesystem>) {
         val uniqueFilesystems = currentFilesystems.subtract(prevFilesystems)
         if (uniqueFilesystems.isNotEmpty()) {
-            setFilesystemForSessionTo(uniqueFilesystems.first())
+            updateFilesystemDetailsForSession(uniqueFilesystems.first())
         }
     }
 
-    private fun setFilesystemForSessionTo(filesystem: Filesystem) {
+    private fun updateFilesystemDetailsForSession(filesystem: Filesystem) {
         session.filesystemName = filesystem.name
         session.filesystemId = filesystem.id
     }

--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -45,18 +45,16 @@ class SessionEditFragment : Fragment() {
 
     private val filesystemChangeObserver = Observer<List<Filesystem>> {
         it?.let {
-            val filesystemNameList = ArrayList(it.map { filesystem -> filesystem.name })
-            filesystemNameList.add("Create new")
+            val filesystemNames = ArrayList(it.map { filesystem -> filesystem.name })
+            filesystemNames.add("Create new")
+
             if (it.isEmpty()) {
-                filesystemNameList.add("")
+                filesystemNames.add("")
             }
 
-            val newFilesystem = getNewlyAddedFilesystem(filesystemList, it)
-            if (newFilesystem != null) {
-                updateFilesystemForSession(newFilesystem)
-            }
+            getListDifferenceAndSetNewFilesystem(filesystemList, it)
 
-            val filesystemAdapter = ArrayAdapter(activityContext, android.R.layout.simple_spinner_dropdown_item, filesystemNameList)
+            val filesystemAdapter = ArrayAdapter(activityContext, android.R.layout.simple_spinner_dropdown_item, filesystemNames)
             val filesystemNamePosition = filesystemAdapter.getPosition(session.filesystemName)
             val usedPosition = if (filesystemNamePosition < 0) 0 else filesystemNamePosition
 
@@ -119,9 +117,9 @@ class SessionEditFragment : Fragment() {
                     else -> {
                         // TODO adapter to associate filesystem structure with list items?
                         val filesystem = filesystemList.find { it.name == filesystemName }
-                        if (filesystem != null) {
-                            updateFilesystemForSession(filesystem)
-                            text_input_username.setText(filesystem.defaultUsername)
+                        filesystem?.run {
+                            setFilesystemForSessionTo(this)
+                            text_input_username.setText(this.defaultUsername)
                         }
                     }
                 }
@@ -209,19 +207,14 @@ class SessionEditFragment : Fragment() {
         }
     }
 
-    private fun getNewlyAddedFilesystem(prevFilesystemList: List<Filesystem>, currentfilesystemList: List<Filesystem>): Filesystem? {
-        if (prevFilesystemList.isEmpty()) {
-            return null
-        }
-
-        val uniqueFilesystems = currentfilesystemList.subtract(prevFilesystemList)
-        return when (uniqueFilesystems.size) {
-            1 -> uniqueFilesystems.first()
-            else -> null
+    private fun getListDifferenceAndSetNewFilesystem(prevFilesystems: List<Filesystem>, currentFilesystems: List<Filesystem>) {
+        val uniqueFilesystems = currentFilesystems.subtract(prevFilesystems)
+        if (uniqueFilesystems.isNotEmpty()) {
+            setFilesystemForSessionTo(uniqueFilesystems.first())
         }
     }
 
-    private fun updateFilesystemForSession(filesystem: Filesystem) {
+    private fun setFilesystemForSessionTo(filesystem: Filesystem) {
         session.filesystemName = filesystem.name
         session.filesystemId = filesystem.id
     }


### PR DESCRIPTION

**Describe the pull request**

**Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.**

In the session edit screen, after creating a new filesystem, the spinner will already have the newly created filesystem selected.


![new_filesystem](https://user-images.githubusercontent.com/11577853/43919642-6b0bd238-9bcb-11e8-9db3-a582fde88b87.gif)




**Link to relevant issues**
#164 