### PR TITLE
Change timestamps to be updated on successful download.

### DIFF
--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -74,7 +74,7 @@ class ServerService : Service() {
     private fun initDownloadUtility(): DownloadUtility {
         val downloadManager = this.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         return DownloadUtility(downloadManager, timestampPreferences,
-                RequestGenerator(), EnvironmentWrapper().getDownloadsDirectory(), this.filesDir)
+                DownloadManagerWrapper(), EnvironmentWrapper().getDownloadsDirectory(), this.filesDir)
     }
 
     override fun onCreate() {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -128,15 +129,33 @@ class ConnectionUtility {
     }
 }
 
-class RequestGenerator {
-    fun generateTypicalDownloadRequest(url: String, destination: String): DownloadManager.Request {
+class DownloadManagerWrapper {
+    fun generateDownloadRequest(url: String, destination: String): DownloadManager.Request {
         val uri = Uri.parse(url)
         val request = DownloadManager.Request(uri)
         request.setAllowedNetworkTypes(DownloadManager.Request.NETWORK_WIFI or DownloadManager.Request.NETWORK_MOBILE)
+        request.setTitle(destination)
         request.setDescription("Downloading ${destination.substringAfterLast(":")}.")
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE)
         request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, destination)
         return request
+    }
+
+    fun generateQuery(id: Long): DownloadManager.Query {
+        val query = DownloadManager.Query()
+        query.setFilterById(id)
+        return query
+    }
+
+    fun generateCursor(downloadManager: DownloadManager, query: DownloadManager.Query): Cursor {
+        return downloadManager.query(query)
+    }
+
+    fun getDownloadTitle(cursor: Cursor): String {
+        if (cursor.moveToFirst()) {
+            return cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_TITLE))
+        }
+        return ""
     }
 }
 

--- a/app/src/main/java/tech/ula/utils/SessionController.kt
+++ b/app/src/main/java/tech/ula/utils/SessionController.kt
@@ -60,7 +60,10 @@ class SessionController(
         resources: Resources
     ) {
         val downloadedIds = ArrayList<Long>()
-        downloadBroadcastReceiver.setDoOnReceived { downloadedIds.add(it) }
+        downloadBroadcastReceiver.setDoOnReceived {
+            downloadedIds.add(it)
+            downloadUtility.setTimestampForDownloadedFile(it)
+        }
         val downloadIds = downloadUtility.downloadRequirements(requiredDownloads)
         while (downloadIds.size != downloadedIds.size) {
             progressBarUpdater(resources.getString(R.string.progress_downloading),


### PR DESCRIPTION
**Describe the pull request**

Timestamps will be updated on successful download instead of on enqueued download.

**Link to relevant issues**
#201