### PR TITLE
Use null object pattern to solve uninitialized function bug.

### DIFF
--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -166,7 +166,7 @@ class EnvironmentWrapper {
 }
 
 class DownloadBroadcastReceiver : BroadcastReceiver() {
-    private lateinit var doOnReceived: (Long) -> Unit
+    private var doOnReceived: (Long) -> Unit = {}
 
     fun setDoOnReceived(action: (Long) -> Unit) {
         doOnReceived = action


### PR DESCRIPTION
Solves:

![image](https://user-images.githubusercontent.com/10427470/44754510-f9794e00-aad6-11e8-830e-c4fb6b376b36.png)
