### PR TITLE
Only allow one session to be run at a time on the session list.

### DIFF
--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -96,18 +96,6 @@ class AppListFragment : Fragment() {
                 is AppItem -> {
                     val selectedApp = selectedItem.app
                     doAppItemClicked(selectedApp)
-
-                    val preferredServiceType = appListViewModel.getAppServiceTypePreference(selectedApp)
-                    if (preferredServiceType.isEmpty()) {
-                        selectServiceTypePreference(selectedApp)
-                    } else {
-                        val serviceIntent = Intent(activityContext, ServerService::class.java)
-                                .putExtra("type", "startApp")
-                                .putExtra("app", selectedApp)
-                                .putExtra("serviceType", preferredServiceType.toLowerCase())
-
-                        activityContext.startService(serviceIntent)
-                    }
                 }
             }
         }
@@ -141,11 +129,17 @@ class AppListFragment : Fragment() {
                 return
             }
 
-            val serviceIntent = Intent(activityContext, ServerService::class.java)
-                    .putExtra("type", "startApp")
-                    .putExtra("app", selectedApp)
-                    .putExtra("serviceType", "ssh") // TODO update this dynamically based on user preference
-            activityContext.startService(serviceIntent)
+            val preferredServiceType = appListViewModel.getAppServiceTypePreference(selectedApp)
+            if (preferredServiceType.isEmpty()) {
+                selectServiceTypePreference(selectedApp)
+            } else {
+                val serviceIntent = Intent(activityContext, ServerService::class.java)
+                        .putExtra("type", "startApp")
+                        .putExtra("app", selectedApp)
+                        .putExtra("serviceType", preferredServiceType.toLowerCase())
+
+                activityContext.startService(serviceIntent)
+            }
         } else {
             passDataToActivity("permissionsRequired")
         }

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -114,7 +114,6 @@ class AppListFragment : Fragment() {
 
     private fun doAppItemClicked(selectedApp: App) {
         if (arePermissionsGranted(activityContext)) {
-            // TODO show description fragment if first time
             if (activeSessions.isNotEmpty()) {
                 if (activeSessions.any { it.name == selectedApp.name }) {
                     val session = activeSessions.find { it.name == selectedApp.name }

--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -106,7 +106,7 @@ class SessionListFragment : Fragment() {
         if (session.active) {
             restartRunningSession(session)
         } else {
-            if (sessionList.any { it.active} ) {
+            if (sessionList.any { it.active }) {
                 Toast.makeText(activityContext, R.string.single_session_supported, Toast.LENGTH_LONG).show()
             } else {
                 startSession(session)

--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -106,7 +106,7 @@ class SessionListFragment : Fragment() {
         if (session.active) {
             restartRunningSession(session)
         } else {
-            if (sessionListViewModel.activeSessions) {
+            if (sessionList.any { it.active} ) {
                 Toast.makeText(activityContext, R.string.single_session_supported, Toast.LENGTH_LONG).show()
             } else {
                 startSession(session)

--- a/app/src/main/java/tech/ula/viewmodel/SessionListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/SessionListViewModel.kt
@@ -3,6 +3,7 @@ package tech.ula.viewmodel
 import android.app.Application
 import android.arch.lifecycle.AndroidViewModel
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.Transformations
 import kotlinx.coroutines.experimental.launch
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.model.entities.Filesystem
@@ -17,8 +18,6 @@ class SessionListViewModel(application: Application) : AndroidViewModel(applicat
     private val sessions: LiveData<List<Session>> by lazy {
         ulaDatabase.sessionDao().getAllSessions()
     }
-
-    var activeSessions: Boolean = false
 
     private val filesystems: LiveData<List<Filesystem>> by lazy {
         ulaDatabase.filesystemDao().getAllFilesystems()

--- a/app/src/main/java/tech/ula/viewmodel/SessionListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/SessionListViewModel.kt
@@ -3,7 +3,6 @@ package tech.ula.viewmodel
 import android.app.Application
 import android.arch.lifecycle.AndroidViewModel
 import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.Transformations
 import kotlinx.coroutines.experimental.launch
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.model.entities.Filesystem


### PR DESCRIPTION
Logic had been removed to appropriately track running sessions on the session list page. Added back in.

Only display ssh/vnc preference selection if a session isn't running, and don't start the service twice.