### PR TITLE
Fix assist structure crash bug.

### DIFF
--- a/app/src/main/res/layout/frag_filesystem_edit.xml
+++ b/app/src/main/res/layout/frag_filesystem_edit.xml
@@ -15,14 +15,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="8dp"
+            android:hint="@string/hint_filesystem_name"
             app:layout_constraintTop_toTopOf="parent" >
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/input_filesystem_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text"
-                android:hint="@string/hint_filesystem_name" />
+                android:inputType="text" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -31,14 +31,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="8dp"
+            android:hint="@string/hint_username"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout">
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/input_filesystem_username"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textNoSuggestions|textVisiblePassword"
-                android:hint="@string/hint_username" />
+                android:inputType="textNoSuggestions|textVisiblePassword" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -47,14 +47,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="8dp"
+            android:hint="@string/hint_password"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_filesystem_username">
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/input_filesystem_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword"
-                android:hint="@string/hint_password" />
+                android:inputType="textPassword" />
+
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
@@ -62,14 +63,15 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="8dp"
+            android:hint="@string/hint_vnc_password"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_filesystem_password">
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/input_filesystem_vncpassword"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword"
-                android:hint="@string/hint_vnc_password" />
+                android:inputType="textPassword" />
+
         </android.support.design.widget.TextInputLayout>
 
         <TextView

--- a/app/src/main/res/layout/frag_session_edit.xml
+++ b/app/src/main/res/layout/frag_session_edit.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
+            android:hint="@string/hint_session_name"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -26,8 +27,7 @@
                 android:id="@+id/text_input_session_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text"
-                android:hint="@string/hint_session_name" />
+                android:inputType="text" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -110,6 +110,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
+            android:hint="@string/hint_username"
             app:layout_constraintTop_toBottomOf="@id/spinner_session_client_type"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" >
@@ -118,8 +119,7 @@
                 android:id="@+id/text_input_username"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text"
-                android:hint="@string/hint_username" />
+                android:inputType="text" />
 
         </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/10427470/46687980-182c3380-cbb1-11e8-8847-6bb683b0b7ef.png">

Hints for `TextInputLayouts` need to be added to the parent and not the nested `TextInputEditText`.

https://stackoverflow.com/questions/45840856/android-8-0-oreo-crash-on-focusing-textinputedittext

