### PR TITLE
Use session to start app.

### DIFF
--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -218,6 +218,12 @@ class ServerService : Service() {
 
             sessionController.ensureFilesystemHasRequiredAssets(filesystem)
 
+            if (session.isAppsSession) {
+                // TODO handle file not downloaded/found case
+                // TODO determine if moving the script to profile.d before extraction is harmful
+                filesystemUtility.moveAppScriptToRequiredLocations(app.name, appsFilesystem)
+            }
+
             val updatedSession = asyncAwait { sessionController.activateSession(session, serverUtility) }
 
             startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
@@ -251,10 +257,6 @@ class ServerService : Service() {
         sessionController.setAppsPassword(password, appSession, appsFilesystem, sessionDao, filesystemDao)
         sessionController.setAppsVncPassword(vncPassword, appSession, appsFilesystem, sessionDao, filesystemDao)
         sessionController.setAppsServiceType(serviceType, appSession, sessionDao)
-
-        // TODO handle file not downloaded/found case
-        // TODO determine if moving the script to profile.d before extraction is harmful
-        filesystemUtility.moveAppScriptToRequiredLocations(app.name, appsFilesystem)
 
         startSession(appSession, appsFilesystem, forceDownloads = false)
     }

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -221,7 +221,7 @@ class ServerService : Service() {
             if (session.isAppsSession) {
                 // TODO handle file not downloaded/found case
                 // TODO determine if moving the script to profile.d before extraction is harmful
-                filesystemUtility.moveAppScriptToRequiredLocations(app.name, appsFilesystem)
+                filesystemUtility.moveAppScriptToRequiredLocations(session.name, filesystem)
             }
 
             val updatedSession = asyncAwait { sessionController.activateSession(session, serverUtility) }


### PR DESCRIPTION
Currently, if you started a session that had been autogenerated for an app, it would just launch the session. Now, it will appropriately start the app it is named after.

This introduces a low-priority bug where if the sessions name is changed, the app will crash. We need to revisit how we track the apps sessions and filesystems anyway for edge cases like this.
