### PR TITLE
Change name of app startup script.

### DIFF
--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -96,9 +96,11 @@ class FilesystemUtility(
 
     fun moveAppScriptToRequiredLocations(appName: String, appFilesystem: Filesystem) {
         // TODO add error cases
+        val fileNameToForceAppScriptToExecuteLast = "zzzzzzzzzzzzzzzz.sh"
         val appScriptSource = File("$applicationFilesDirPath/apps/$appName/$appName.sh")
         val appScriptSupportTarget = File("$applicationFilesDirPath/${appFilesystem.id}/support/$appName.sh")
-        val appScriptProfileDTarget = File("$applicationFilesDirPath/${appFilesystem.id}/etc/profile.d/$appName.sh")
+        val appScriptProfileDTarget = File("$applicationFilesDirPath/${appFilesystem.id}" +
+                "/etc/profile.d/$fileNameToForceAppScriptToExecuteLast")
         appScriptSource.copyTo(appScriptSupportTarget, overwrite = true)
         appScriptSource.copyTo(appScriptProfileDTarget, overwrite = true)
     }

--- a/app/src/main/res/layout/dia_app_credentials.xml
+++ b/app/src/main/res/layout/dia_app_credentials.xml
@@ -56,7 +56,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="@string/hint_password"
+        android:text="@string/hint_vnc_password"
         app:layout_constraintStart_toStartOf="@+id/text_title_username"
         app:layout_constraintTop_toBottomOf="@+id/text_input_password" />
 


### PR DESCRIPTION
By renaming the app startup script to a bunch of z's while it is briefly in profile.d (it is deleted immediately on execution), it should execute as the last step no matter what else is in the directory.