### PR TITLE
Rearrange order of empty filesystem option and "Create new" option so that empty filesystem option appears first when no filesystems exist

### DIFF
--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -51,7 +51,7 @@ class SessionEditFragment : Fragment() {
             if (it.isEmpty()) {
                 filesystemNames.add("")
             }
-            
+
             filesystemNames.add("Create new")
 
             getListDifferenceAndSetNewFilesystem(filesystemList, it)

--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -47,11 +47,12 @@ class SessionEditFragment : Fragment() {
         it?.let {
             val filesystemNames = ArrayList(it.map { filesystem ->
                 "${filesystem.name}: ${filesystem.distributionType.capitalize()}" })
-            filesystemNames.add("Create new")
 
             if (it.isEmpty()) {
                 filesystemNames.add("")
             }
+            
+            filesystemNames.add("Create new")
 
             getListDifferenceAndSetNewFilesystem(filesystemList, it)
 


### PR DESCRIPTION
**Describe the pull request**

Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.


Fixes bug where opening create session page would directly take the user to the filesystem edit page.

**Link to relevant issues**
