### PR TITLE
Production clean up

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -143,6 +143,9 @@ class MainActivity : AppCompatActivity() {
             "playStoreMissingForClient" ->
                 displayGenericErrorDialog(this, R.string.alert_need_client_app_title,
                     R.string.alert_need_client_app_message)
+            "networkTooWeakForDownloads" ->
+                displayGenericErrorDialog(this, R.string.general_error_title,
+                        R.string.alert_network_strength_too_low_for_downloads)
         }
     }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -42,8 +42,11 @@ class MainActivity : AppCompatActivity() {
             intent?.let {
                 val type = it.getStringExtra("type")
                 when (type) {
-                    "startProgressBar" -> startProgressBar()
-                    "updateProgressBar" -> updateProgressBar(it)
+                    "updateProgressBar" -> {
+                        val step = intent.getStringExtra("step")
+                        val details = intent.getStringExtra("details")
+                        updateProgressBar(step, details)
+                    }
                     "killProgressBar" -> killProgressBar()
                     "isProgressBarActive" -> syncProgressBarDisplayedWithService(it)
                     "displayNetworkChoices" -> displayNetworkChoicesDialog()
@@ -143,17 +146,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun startProgressBar() {
-        if (!currentFragmentDisplaysProgressDialog) return
-
-        val inAnimation = AlphaAnimation(0f, 1f)
-        inAnimation.duration = 200
-        layout_progress.animation = inAnimation
-        layout_progress.visibility = View.VISIBLE
-        layout_progress.isFocusable = true
-        layout_progress.isClickable = true
-    }
-
     private fun killProgressBar() {
         val outAnimation = AlphaAnimation(1f, 0f)
         outAnimation.duration = 200
@@ -163,22 +155,26 @@ class MainActivity : AppCompatActivity() {
         layout_progress.isClickable = false
     }
 
-    private fun updateProgressBar(intent: Intent) {
+    private fun updateProgressBar(step: String, details: String) {
         if (!currentFragmentDisplaysProgressDialog) return
 
-        layout_progress.visibility = View.VISIBLE
-        layout_progress.isFocusable = true
-        layout_progress.isClickable = true
+        if (layout_progress.visibility != View.VISIBLE) {
+            val inAnimation = AlphaAnimation(0f, 1f)
+            inAnimation.duration = 200
+            layout_progress.animation = inAnimation
 
-        val step = intent.getStringExtra("step")
-        val details = intent.getStringExtra("details")
+            layout_progress.visibility = View.VISIBLE
+            layout_progress.isFocusable = true
+            layout_progress.isClickable = true
+        }
+
         text_session_list_progress_step.text = step
         text_session_list_progress_details.text = details
     }
 
     private fun syncProgressBarDisplayedWithService(intent: Intent) {
         val isActive = intent.getBooleanExtra("isProgressBarActive", false)
-        if (isActive) startProgressBar()
+        if (isActive) updateProgressBar("", "")
         else killProgressBar()
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -207,7 +207,7 @@ class ServerService : Service() {
                 is RequiredAssetsResult -> requiredDownloads = downloadRequirementsResult.assetList
             }
 
-            if (requiredDownloads.isNotEmpty() && ConnectionUtility().hostIsReachable("https://github.com/CypherpunkArmory/UserLAnd-Assets-Support/raw/master/apps)")) {
+            if (requiredDownloads.isNotEmpty() && !ConnectionUtility().httpsHostIsReachable("github.com")) {
                 dialogBroadcaster("networkTooWeakForDownloads")
                 return@launch
             }

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -102,7 +102,6 @@ class ServerService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
-        startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
         val intentType = intent?.getStringExtra("type")
         when (intentType) {
             "start" -> {
@@ -175,6 +174,8 @@ class ServerService : Service() {
         lastActivatedSession = session
         lastActivatedFilesystem = filesystem
 
+        startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
+
         val assetRepository = AssetRepository(BuildWrapper().getArchType(),
                 filesystem.distributionType,
                 this.filesDir.path,
@@ -184,8 +185,6 @@ class ServerService : Service() {
         val sessionController = SessionController(assetRepository, filesystemUtility)
 
         launch(CommonPool) {
-
-            startProgressBar()
 
             progressBarUpdater(resources.getString(R.string.progress_fetching_asset_lists), "")
             val assetLists = asyncAwait {
@@ -248,6 +247,8 @@ class ServerService : Service() {
     }
 
     private fun startApp(app: App, serviceType: String, username: String = "", password: String = "", vncPassword: String = "") {
+        progressBarUpdater(getString(R.string.progress_basic_app_setup), "")
+
         val appsFilesystemDistType = app.filesystemRequired
 
         val assetRepository = AssetRepository(BuildWrapper().getArchType(),
@@ -343,14 +344,6 @@ class ServerService : Service() {
                 .forEach { killSession(it) }
 
         filesystemUtility.deleteFilesystem(filesystemId)
-    }
-
-    private fun startProgressBar() {
-        val intent = Intent(SERVER_SERVICE_RESULT)
-                .putExtra("type", "startProgressBar")
-        broadcaster.sendBroadcast(intent)
-
-        progressBarActive = true
     }
 
     private fun killProgressBar() {

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -102,6 +102,7 @@ class ServerService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
+        startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
         val intentType = intent?.getStringExtra("type")
         when (intentType) {
             "start" -> {
@@ -238,7 +239,6 @@ class ServerService : Service() {
 
             val updatedSession = asyncAwait { sessionController.activateSession(session, serverUtility) }
 
-            startForeground(NotificationUtility.serviceNotificationId, notificationManager.buildPersistentServiceNotification())
             updatedSession.active = true
             updateSession(updatedSession)
             killProgressBar()

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -207,6 +207,10 @@ class ServerService : Service() {
                 is RequiredAssetsResult -> requiredDownloads = downloadRequirementsResult.assetList
             }
 
+            if (requiredDownloads.isNotEmpty() && ConnectionUtility().hostIsReachable("https://github.com/CypherpunkArmory/UserLAnd-Assets-Support/raw/master/apps)")) {
+                dialogBroadcaster("networkTooWeakForDownloads")
+                return@launch
+            }
             asyncAwait {
                 sessionController.downloadRequirements(requiredDownloads, downloadBroadcastReceiver,
                         initDownloadUtility(), progressBarUpdater, resources)
@@ -254,6 +258,7 @@ class ServerService : Service() {
         val assetRepository = AssetRepository(BuildWrapper().getArchType(),
                 appsFilesystemDistType, this.filesDir.path, timestampPreferences,
                 assetListPreferences)
+        // TODO refactor this to not instantiate twice
         val sessionController = SessionController(assetRepository, filesystemUtility)
 
         val filesystemDao = UlaDatabase.getInstance(this).filesystemDao()

--- a/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
+++ b/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
@@ -11,6 +11,8 @@ import java.net.URL
 import javax.net.ssl.SSLHandshakeException
 
 interface RemoteAppsSource {
+    fun getHostname(): String
+
     suspend fun fetchAppsList(): List<App>
 
     suspend fun fetchAppIcon(app: App)
@@ -29,6 +31,9 @@ class GithubAppsFetcher(private val applicationFilesDir: String, private val con
     private val branch = "master" // Base off different support branches for testing.
     private val baseUrl = "://github.com/CypherpunkArmory/UserLAnd-Assets-Support/raw/$branch/apps"
     private var protocol = "https"
+    private val hostname = "$protocol$baseUrl"
+
+    override fun getHostname(): String { return hostname }
 
     @Throws
     override suspend fun fetchAppsList(): List<App> {

--- a/app/src/main/java/tech/ula/model/repositories/AppsRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AppsRepository.kt
@@ -33,7 +33,7 @@ class AppsRepository(
     suspend fun refreshData() {
         val appsList = mutableSetOf<String>()
         val distributionsList = mutableSetOf<String>()
-        if (!ConnectionUtility().hostIsReachable(remoteAppsSource.getHostname())) {
+        if (!ConnectionUtility().httpsHostIsReachable("github.com")) {
             refreshStatus.postValue(RefreshStatus.FAILED)
             return
         }

--- a/app/src/main/java/tech/ula/model/repositories/AppsRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AppsRepository.kt
@@ -7,6 +7,7 @@ import tech.ula.model.daos.AppsDao
 import tech.ula.model.entities.App
 import tech.ula.model.remote.RemoteAppsSource
 import tech.ula.utils.AppsPreferences
+import tech.ula.utils.ConnectionUtility
 
 import tech.ula.utils.asyncAwait
 
@@ -32,6 +33,10 @@ class AppsRepository(
     suspend fun refreshData() {
         val appsList = mutableSetOf<String>()
         val distributionsList = mutableSetOf<String>()
+        if (!ConnectionUtility().hostIsReachable(remoteAppsSource.getHostname())) {
+            refreshStatus.postValue(RefreshStatus.FAILED)
+            return
+        }
         asyncAwait {
             refreshStatus.postValue(RefreshStatus.ACTIVE)
             try {

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -60,7 +60,7 @@ class AssetRepository(
         val url = "$protocol://github.com/CypherpunkArmory/UserLAnd-Assets-" +
                 "$assetType/raw/master/assets/$architectureType/assets.txt"
 
-        if (!connectionUtility.hostIsReachable(url)) throw object : Exception("Host is unreachable.") {}
+        if (!connectionUtility.httpsHostIsReachable("github.com")) throw object : Exception("Host is unreachable.") {}
         try {
             val reader = BufferedReader(InputStreamReader(connectionUtility.getUrlInputStream(url)))
 

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -59,6 +59,8 @@ class AssetRepository(
 
         val url = "$protocol://github.com/CypherpunkArmory/UserLAnd-Assets-" +
                 "$assetType/raw/master/assets/$architectureType/assets.txt"
+
+        if (!connectionUtility.hostIsReachable(url)) throw object : Exception("Host is unreachable.") {}
         try {
             val reader = BufferedReader(InputStreamReader(connectionUtility.getUrlInputStream(url)))
 

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -332,6 +332,7 @@ class AppListFragment : Fragment(), PlayServiceManager.PlayServicesUpdateListene
 
                     if (appListViewModel.getAppServiceTypePreference(selectedApp).isEmpty()) {
                         getClientPreferenceAndStart(selectedApp, username, password, vncPassword)
+                        return@setOnClickListener
                     }
 
                     val serviceTypePreference = appListViewModel.getAppServiceTypePreference(selectedApp)

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -484,6 +484,6 @@ class AppListFragment : Fragment(), PlayServiceManager.PlayServicesUpdateListene
     }
 
     override fun onSubscriptionPurchased() {
-        if (lastSelectedApp != unselectedApp) handleAppSelection(lastSelectedApp)
+        handleAppSelection(lastSelectedApp)
     }
 }

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -188,6 +188,7 @@ class AppListFragment : Fragment(), PlayServiceManager.PlayServicesUpdateListene
     }
 
     private fun handleAppSelection(selectedApp: App) {
+        if (selectedApp == unselectedApp) return
         if (selectedApp.isPaidApp) {
             when {
                 !playServiceManager.playStoreIsAvailable(activityContext.packageManager) -> {

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -111,6 +111,8 @@ class AppListFragment : Fragment(), PlayServiceManager.PlayServicesUpdateListene
         it?.let {
             refreshStatus = it
             swipe_refresh.isRefreshing = refreshStatus == RefreshStatus.ACTIVE
+
+            if (refreshStatus == RefreshStatus.FAILED) showRefreshUnavailableDialog()
         }
     }
 
@@ -455,6 +457,17 @@ class AppListFragment : Fragment(), PlayServiceManager.PlayServicesUpdateListene
                 }
             }
         }
+    }
+
+    private fun showRefreshUnavailableDialog() {
+        AlertDialog.Builder(activityContext)
+                .setMessage(R.string.alert_network_required_for_refresh)
+                .setTitle(R.string.general_error_title)
+                .setPositiveButton(R.string.button_ok) {
+                    dialog, _ ->
+                    dialog.dismiss()
+                }
+                .create().show()
     }
 
     override fun onSubscriptionsAreNotSupported() {

--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -47,11 +47,12 @@ class SessionEditFragment : Fragment() {
         it?.let {
             val filesystemNames = ArrayList(it.map { filesystem ->
                 "${filesystem.name}: ${filesystem.distributionType.capitalize()}" })
-            filesystemNames.add("Create new")
 
             if (it.isEmpty()) {
                 filesystemNames.add("")
             }
+
+            filesystemNames.add("Create new")
 
             getListDifferenceAndSetNewFilesystem(filesystemList, it)
 

--- a/app/src/main/java/tech/ula/ui/SessionListAdapter.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListAdapter.kt
@@ -88,7 +88,7 @@ class SessionListAdapter(
             }
             is SessionItem -> {
                 val session = item.session
-                val filesystem = filesystems.find { it.id == session.filesystemId }!!
+                val filesystem = filesystems.find { it.id == session.filesystemId } ?: Filesystem(0, name = "ERROR")
 
                 if (session.active) {
                     view?.setBackgroundResource(R.color.colorAccent)

--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -33,7 +33,8 @@ class SessionListFragment : Fragment() {
     private lateinit var sessionAdapter: SessionListAdapter
     private lateinit var filesystemList: List<Filesystem>
 
-    private lateinit var lastSelectedSession: Session
+    private val unselectedSession = Session(id = 0, name = "UNSELECTED", filesystemId = 0)
+    private var lastSelectedSession = unselectedSession
 
     private val sessionListViewModel: SessionListViewModel by lazy {
         ViewModelProviders.of(this).get(SessionListViewModel::class.java)
@@ -100,6 +101,7 @@ class SessionListFragment : Fragment() {
     }
 
     private fun handleSessionSelection(session: Session) {
+        if (session == unselectedSession) return
         if (session.active) {
             restartRunningSession(session)
         } else {

--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -163,7 +163,7 @@ class SessionListFragment : Fragment() {
             val serviceIntent = Intent(activityContext, ServerService::class.java)
             serviceIntent.putExtra("type", "kill")
             serviceIntent.putExtra("session", session)
-            activityContext.startForegroundService(serviceIntent)
+            activityContext.startService(serviceIntent)
         }
         return true
     }

--- a/app/src/main/java/tech/ula/ui/SessionListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionListFragment.kt
@@ -161,7 +161,7 @@ class SessionListFragment : Fragment() {
             val serviceIntent = Intent(activityContext, ServerService::class.java)
             serviceIntent.putExtra("type", "kill")
             serviceIntent.putExtra("session", session)
-            activityContext.startService(serviceIntent)
+            activityContext.startForegroundService(serviceIntent)
         }
         return true
     }

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -22,6 +22,7 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URL
@@ -186,10 +187,9 @@ class BuildWrapper {
 }
 
 class ConnectionUtility {
-    fun hostIsReachable(hostname: String): Boolean {
-        val port = if (hostname.contains("https")) 443 else 80
+    fun httpsHostIsReachable(hostname: String): Boolean {
         return try {
-            val sockaddr = InetSocketAddress(hostname, port)
+            val sockaddr = InetSocketAddress(hostname, 443)
             val sock = Socket()
             val timeout = 2000
 

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -22,7 +22,6 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URL

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -19,8 +19,11 @@ import android.support.v4.content.ContextCompat
 import tech.ula.R
 import tech.ula.model.entities.Asset
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.net.URL
 
 fun makePermissionsUsable(containingDirectoryPath: String, filename: String) {
@@ -183,6 +186,20 @@ class BuildWrapper {
 }
 
 class ConnectionUtility {
+    fun hostIsReachable(hostname: String): Boolean {
+        val port = if (hostname.contains("https")) 443 else 80
+        return try {
+            val sockaddr = InetSocketAddress(hostname, port)
+            val sock = Socket()
+            val timeout = 2000
+
+            sock.connect(sockaddr, timeout)
+            true
+        } catch (err: IOException) {
+            false
+        }
+    }
+
     @Throws(Exception::class)
     fun getUrlConnection(url: String): HttpURLConnection {
         return URL(url).openConnection() as HttpURLConnection

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="service_notification_description">UserLAnd is running a background service.</string>
 
     <!-- Progress bar messages -->
+    <string name="progress_basic_app_setup">Setting up app database information&#8230;</string>
     <string name="progress_fetching_asset_lists">Fetching asset lists&#8230;</string>
     <string name="progress_checking_for_required_updates">Checking whether updates are required&#8230;</string>
     <string name="progress_downloading">Downloading required assets&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <!-- Network unavailable alert -->
     <string name="alert_network_unavailable_title">No network available</string>
     <string name="alert_network_unavailable_message">UserLAnd requires network availability to download required assets.</string>
+    <string name="alert_network_required_for_refresh">Refreshing apps requires an available or stronger network connection.</string>
+    <string name="alert_network_strength_too_low_for_downloads">Your network strength is too low to download required assets. Please try again with a strong connection.</string>
 
     <!-- Asset list failure alert -->
     <string name="alert_asset_list_failure_title">Could not retrieve asset lists.</string>

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -90,7 +90,9 @@ class AssetRepositoryTest {
 
         allUrlsWithoutProtocols.forEach {
             `when`(connectionUtility.getUrlInputStream("https$it")).thenThrow(SSLHandshakeException::class.java)
+            `when`(connectionUtility.hostIsReachable("https$it")).thenReturn(true)
             `when`(connectionUtility.getUrlInputStream("http$it")).thenReturn(inputStream)
+            `when`(connectionUtility.hostIsReachable("http$it")).thenReturn(true)
         }
 
         assetRepository.retrieveAllRemoteAssetLists()

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -90,9 +90,8 @@ class AssetRepositoryTest {
 
         allUrlsWithoutProtocols.forEach {
             `when`(connectionUtility.getUrlInputStream("https$it")).thenThrow(SSLHandshakeException::class.java)
-            `when`(connectionUtility.hostIsReachable("https$it")).thenReturn(true)
+            `when`(connectionUtility.httpsHostIsReachable("github.com")).thenReturn(true)
             `when`(connectionUtility.getUrlInputStream("http$it")).thenReturn(inputStream)
-            `when`(connectionUtility.hostIsReachable("http$it")).thenReturn(true)
         }
 
         assetRepository.retrieveAllRemoteAssetLists()


### PR DESCRIPTION
Cleans up some bugs currently in production.

- Avoids a couple places where `lateinit var`s were uninitialized on reference.
- Start service in foreground earlier to avoid illegal states and get notification running as soon as background work begins.
- Display progress dialog while apps are setting db info up. May fix ANRs.
- Check network reachability before network interactions.
