### PR TITLE
Filesystems page will listen to progress bar dialog and display it when navigating to it.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -69,7 +69,8 @@ class MainActivity : AppCompatActivity() {
         navController.addOnNavigatedListener { _, destination ->
             currentFragmentDisplaysProgressDialog =
                     destination.label == getString(R.string.sessions) ||
-                    destination.label == getString(R.string.apps)
+                    destination.label == getString(R.string.apps) ||
+                    destination.label == getString(R.string.filesystems)
             if (!currentFragmentDisplaysProgressDialog) killProgressBar()
         }
 


### PR DESCRIPTION


**Describe the pull request**

Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.

When an app or session is starting, the filesystem page elements should not be able to interact with.  This will also eliminate the ability to select on an element when switching to the sessions or apps tab.  (Brief moment where elements are able to be selected before the progress bar appears, e.g. selecting another app)

**Link to relevant issues**
