### PR TITLE
pass kernel version down so we can fake out /proc/version

### DIFF
--- a/app/src/main/java/tech/ula/utils/ExecUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ExecUtility.kt
@@ -44,7 +44,8 @@ class ExecUtility(
                 "ROOT_PATH" to applicationFilesDirPath,
                 "ROOTFS_PATH" to "$applicationFilesDirPath/${executionDirectory.name}",
                 "PROOT_DEBUG_LEVEL" to prootDebuggingLevel,
-                "EXTRA_BINDINGS" to "-b $externalStoragePath:/sdcard")
+                "EXTRA_BINDINGS" to "-b $externalStoragePath:/sdcard",
+                "OS_VERSION" to System.getProperty("os.version"))
         else hashMapOf()
 
         env.putAll(environmentVars)


### PR DESCRIPTION
**Describe the pull request**

/proc/version is not readable on newer versions of android.  passing down the kernel version will allow us to recreate a reasonable file and then bind that file to /proc/version working around this issue.  

this has been tested to work, but we need this PR to go through and be released in addition to a change to the support repo to use this environment variable.

**Link to relevant issues**

#92 #323 


