### PR TITLE
Fix: Apps Service Type Behavior

### DIFF
--- a/app/src/main/java/tech/ula/ui/AppDetailsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppDetailsFragment.kt
@@ -42,7 +42,16 @@ class AppDetailsFragment : Fragment() {
         setupPreferredServiceTypeRadioGroup()
     }
 
-    fun setupPreferredServiceTypeRadioGroup() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (!(app.supportsGui && app.supportsCli)) {
+            apps_vnc_preference.isEnabled = false
+            apps_ssh_preference.isEnabled = false
+            return
+        }
+    }
+
+    private fun setupPreferredServiceTypeRadioGroup() {
         val appServiceTypePreference = appsPreferences.getAppServiceTypePreference(app.name)
         if (appServiceTypePreference == AppsPreferences.SSH) {
             apps_service_type_preferences.check(R.id.apps_ssh_preference)

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -228,10 +228,14 @@ class AppListFragment : Fragment(),
             // TODO some error notification
             return
         }
+
         val appFilesystem = possibleAppFilesystem.first()
-        if (appsListViewModel.getAppServiceTypePreference(selectedApp).isEmpty()) {
-            getClientPreferenceAndStart(selectedApp, appFilesystem.defaultUsername, appFilesystem.defaultPassword, appFilesystem.defaultVncPassword)
-            return
+
+        if (!appSupportsOneServiceTypeAndSetPref(selectedApp)) {
+            if (appsListViewModel.getAppServiceTypePreference(selectedApp).isEmpty()) {
+                getClientPreferenceAndStart(selectedApp, appFilesystem.defaultUsername, appFilesystem.defaultPassword, appFilesystem.defaultVncPassword)
+                return
+            }
         }
 
         val startAppIntent = Intent(activityContext, ServerService::class.java)


### PR DESCRIPTION
## What changes does this PR introduce


Previously if an apps filesystem already existed and a new app was selected (which only supported one service type), then it would prompt a service type to use.  This PR will set the preference automatically and start the session right away (with the app's only supported service type).

Previously, if an app was only supported by one service type (ssh/vnc), the ability to change the preference in the Apps Detail page was still available.  This PR will disable the ability to change the preference.

## Where should the reviewer start?

`AppListFragment.kt`
`AppDetailsFragment.kt`

## Has this been manually tested? How?

Cleared the data and selected Firefox which only supports VNC.  Now it starts automatically after entering in username/password/vncPassword.  Also long pressing it and viewing the details page, I shouldn't be able to change it to VNC.  

## What GIF best describes this PR or how it makes you feel?
![n0ice job](https://media.giphy.com/media/CTX0ivSQbI78A/giphy.gif "Sliced pickles wrapped in ham is tasty")