### PR TITLE
Hotfix for terminal NPE bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ reference:
     environment:
       TERM: dumb
       # Limit JVM heap size to prevent exceeding container memory
-      _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
+      _JAVA_OPTIONS: "-Xmx1536m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m" -Dorg.gradle.parallel=true'
 
   export_gcloud_key: &export_gcloud_key
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ reference:
     environment:
       TERM: dumb
       # Limit JVM heap size to prevent exceeding container memory
-      _JAVA_OPTIONS: "-Xmx3200m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3200m"'
+      _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
 
   export_gcloud_key: &export_gcloud_key
     run:

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true

--- a/termux-app/gradle.properties
+++ b/termux-app/gradle.properties
@@ -11,5 +11,5 @@
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2048M

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -302,7 +302,13 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
             throw new RuntimeException("TermuxActivity dataString from Intent does not have any data");
         }
 
-        serviceIntent.putExtra("intentData", intentData);
+        parseUserlandIntent(intentData);
+
+        serviceIntent.putExtra("username", username);
+        serviceIntent.putExtra("hostname", hostname);
+        serviceIntent.putExtra("port", port);
+        serviceIntent.putExtra("sessionName", sessionName);
+
         serviceIntent.setAction(TermuxService.ACTION_EXECUTE);
 
         // Start the service and make it run regardless of who is bound to it:
@@ -313,6 +319,33 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         checkForFontAndColors();
 
         mBellSoundId = mBellSoundPool.load(this, R.raw.bell, 1);
+    }
+
+    /** Parse intent for connection parameters **/
+    private String username = "";
+    private String hostname = "";
+    private String port = "";
+    private String sessionName = "";
+
+    private void parseUserlandIntent(String intentData) {
+        String regexPattern = "ssh://([\\w\\W]+)@([\\w\\W]+):([\\d]+)/#([\\w\\W]+)";
+        Pattern pattern = Pattern.compile(regexPattern);
+
+        try {
+            Matcher matcher = pattern.matcher(intentData);
+            if (matcher.groupCount() < 4) {
+                return;
+            }
+
+            if (matcher.find()) {
+                username = matcher.group(1);
+                hostname = matcher.group(2);
+                port = matcher.group(3);
+                sessionName = matcher.group(4);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error occurred while parsing intent data with regex: " + e);
+        }
     }
 
     void toggleShowExtraKeys() {

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -98,8 +98,6 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
     private static final String RELOAD_STYLE_ACTION = "com.termux.app.reload_style";
 
-    protected Uri intentData;
-
     /** The main view of the activity showing the terminal. Initialized in onCreate(). */
     @SuppressWarnings("NullableProblems")
     @NonNull
@@ -299,8 +297,12 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         registerForContextMenu(mTerminalView);
 
         Intent serviceIntent = new Intent(this, TermuxService.class);
-        intentData = getIntent().getData();
-        serviceIntent.setData(intentData);
+        String intentData = getIntent().getDataString();
+        if (intentData == null || intentData.isEmpty()) {
+            throw new RuntimeException("TermuxActivity dataString from Intent does not have any data");
+        }
+
+        serviceIntent.putExtra("intentData", intentData);
         serviceIntent.setAction(TermuxService.ACTION_EXECUTE);
 
         // Start the service and make it run regardless of who is bound to it:

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -11,6 +11,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
@@ -299,7 +300,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         Intent serviceIntent = new Intent(this, TermuxService.class);
         String intentData = getIntent().getDataString();
         if (intentData == null || intentData.isEmpty()) {
-            Log.e(EmulatorDebug.LOG_TAG, "Currently only intents from UserLAnd are supported");
+            showErrorAndGoBackToUserland("Intent data is empty.  Only UserLAnd intents are supported");
             return;
         }
 
@@ -345,8 +346,24 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 sessionName = matcher.group(4);
             }
         } catch (Exception e) {
-            throw new RuntimeException("Error occurred while parsing intent data with regex: " + e);
+            showErrorAndGoBackToUserland("Error occurred while parsing intent data with regex: " + e);
         }
+    }
+
+    public void showErrorAndGoBackToUserland(String errorMessage) {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+
+        alertDialogBuilder.setTitle("An error has occurred")
+                .setMessage(errorMessage)
+                .setCancelable(true)
+                .setPositiveButton("Exit",new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // if this button is clicked, close current activity
+                        finish();
+                    }
+                });
+        AlertDialog alertDialog = alertDialogBuilder.create();
+        alertDialog.show();
     }
 
     void toggleShowExtraKeys() {

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -28,6 +28,7 @@ import android.os.IBinder;
 import android.os.Vibrator;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
@@ -70,9 +71,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static android.content.ContentValues.TAG;
-import static java.sql.DriverManager.println;
 
 /**
  * A terminal emulator activity.
@@ -300,7 +298,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         Intent serviceIntent = new Intent(this, TermuxService.class);
         String intentData = getIntent().getDataString();
         if (intentData == null || intentData.isEmpty()) {
-            showErrorAndGoBackToUserland("Intent data is empty.  Only UserLAnd intents are supported");
+            showErrorAndGoBackToUserland(R.string.error_empty_intent_data, "");
             return;
         }
 
@@ -346,20 +344,22 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 sessionName = matcher.group(4);
             }
         } catch (Exception e) {
-            showErrorAndGoBackToUserland("Error occurred while parsing intent data with regex: " + e);
+            showErrorAndGoBackToUserland(R.string.error_regex_parsing, e.getMessage());
         }
     }
 
-    public void showErrorAndGoBackToUserland(String errorMessage) {
+    void showErrorAndGoBackToUserland(@StringRes int resId, String extraInfo) {
+        Context appContext = getApplicationContext();
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        String errorMessage = appContext.getString(resId);
 
-        alertDialogBuilder.setTitle("An error has occurred")
-                .setMessage(errorMessage)
+        alertDialogBuilder.setTitle(R.string.dialog_error_title)
+                .setMessage(errorMessage + ", " + extraInfo)
                 .setCancelable(true)
-                .setPositiveButton("Exit",new DialogInterface.OnClickListener() {
+                .setPositiveButton(R.string.button_exit, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         // if this button is clicked, close current activity
-                        finish();
+                        TermuxActivity.this.finish();
                     }
                 });
         AlertDialog alertDialog = alertDialogBuilder.create();

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -299,7 +299,8 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         Intent serviceIntent = new Intent(this, TermuxService.class);
         String intentData = getIntent().getDataString();
         if (intentData == null || intentData.isEmpty()) {
-            throw new RuntimeException("TermuxActivity dataString from Intent does not have any data");
+            Log.e(EmulatorDebug.LOG_TAG, "Currently only intents from UserLAnd are supported");
+            return;
         }
 
         parseUserlandIntent(intentData);

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -128,10 +128,10 @@ public final class TermuxService extends Service implements SessionChangedCallba
                 updateNotification();
             }
         } else if (ACTION_EXECUTE.equals(action)) {
-            String username = intent.getStringExtra("username");
-            String hostname = intent.getStringExtra("hostname");
-            String port = intent.getStringExtra("port");
-            String sessionName = intent.getStringExtra("sessionName");
+            username = intent.getStringExtra("username");
+            hostname = intent.getStringExtra("hostname");
+            port = intent.getStringExtra("port");
+            sessionName = intent.getStringExtra("sessionName");
 
             if (username.isEmpty() || hostname.isEmpty() || port.isEmpty() || sessionName.isEmpty()) {
                 Log.e(EmulatorDebug.LOG_TAG, "Currently only intents from UserLAnd are supported");

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -70,6 +70,11 @@ public final class TermuxService extends Service implements SessionChangedCallba
 
     private final Handler mHandler = new Handler();
 
+    String username = "";
+    String hostname = "";
+    String port = "";
+    String sessionName = "";
+
     /**
      * The terminal sessions which this service manages.
      * <p/>
@@ -89,29 +94,6 @@ public final class TermuxService extends Service implements SessionChangedCallba
 
     /** If the user has executed the {@link #ACTION_STOP_SERVICE} intent. */
     boolean mWantsToStop = false;
-
-    /** Parse intent for connection parameters **/
-    private String username = "";
-    private String hostname = "";
-    private String port = "";
-    private String sessionName = "";
-
-    private void parseUserlandIntent(String intentData) {
-        String regexPattern = "ssh://([\\w\\W]+)@([\\w\\W]+):([\\d]+)/#([\\w\\W]+)";
-        Pattern pattern = Pattern.compile(regexPattern);
-
-        try {
-            Matcher matcher = pattern.matcher(intentData);
-            if (matcher.find()) {
-                username = matcher.group(1);
-                hostname = matcher.group(2);
-                port = matcher.group(3);
-                sessionName = matcher.group(4);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Regex could not be used to parse the intent String" + e);
-        }
-    }
 
     @SuppressLint("Wakelock")
     @Override
@@ -146,11 +128,17 @@ public final class TermuxService extends Service implements SessionChangedCallba
                 updateNotification();
             }
         } else if (ACTION_EXECUTE.equals(action)) {
-            String executablePath = intent.getStringExtra("intentData");
-            parseUserlandIntent(executablePath);
+            String username = intent.getStringExtra("username");
+            String hostname = intent.getStringExtra("hostname");
+            String port = intent.getStringExtra("port");
+            String sessionName = intent.getStringExtra("sessionName");
 
-            // Launch the main Termux app, which will now show the current session:
-            startActivity(new Intent(this, TermuxActivity.class).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+            if (username.isEmpty() || hostname.isEmpty() || port.isEmpty() || sessionName.isEmpty()) {
+                Log.e(EmulatorDebug.LOG_TAG, "Currently only intents from UserLAnd are supported");
+            } else {
+                // Launch the main Termux app, which will now show the current session:
+                startActivity(new Intent(this, TermuxActivity.class).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+            }
         } else if (action != null) {
             Log.e(EmulatorDebug.LOG_TAG, "Unknown TermuxService action: '" + action + "'");
         }

--- a/termux-app/terminal-term/src/main/res/values/strings.xml
+++ b/termux-app/terminal-term/src/main/res/values/strings.xml
@@ -36,4 +36,10 @@
   <string name="file_received_edit_button">Edit</string>
   <string name="file_received_open_folder_button">Open folder</string>
 
+  <string name="error_empty_intent_data">Intent data is empty.  Only UserLAnd intents are supported</string>
+  <string name="error_regex_parsing">Error occurred while parsing intent data with regex</string>
+
+  <string name="button_exit">Exit</string>
+  <string name="dialog_error_title">An error has occurred</string>
+
 </resources>


### PR DESCRIPTION
## What changes does this PR introduce?
An attempt at fixing an issue of Null Pointer Exception when parsing SSH intent to UserLAnd's terminal

## Any background context you want to provide?
There are are a couple more enhancements to be made but the main functionality is there.  If users still want to use other SSH clients such as Connectbot, they are able to.  Upon starting a session, there will be a prompt as to which SSH client they want to use (provided other SSH client apps are installed).

## Files Changed

Filename | Path
------------ | -------------
TermuxActivity.java | termux-app/terminal-term/src/main/java/com/termux/app/
TermuxService.java | termux-app/terminal-term/src/main/java/com/termux/app/


## Where should the reviewer start
TermuxActivity line 300 is where UserLAnd's intent gets received.  It sets an IntentExtra to hold the original intent data as a string.  It gets sent to TermuxService line 150 where it is parsed for hostname, username, port and session name.  


## Has this been manually tested? How?
The flow of creating a filesystem and connecting to it via the built in terminal was tested on a Samsung Galaxy S9.


## What GIF best describes this PR or how it makes you feel?
![feels_bad_man](https://media.giphy.com/media/xT9IgIc0lryrxvqVGM/giphy.gif)
