### PR TITLE
Handle terminal notification press

### DIFF
--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -108,7 +108,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
 
     // Don't attempt to unbind from the service unless the client has received some
     // information about the service's state.
-    private boolean shouldUnbind;
+    private boolean shouldUnbind = false;
 
     /**
      * The connection to the {@link TermuxService}. Requested in {@link #onCreate(Bundle)} with a call to


### PR DESCRIPTION
**Describe the pull request**

Fixes the crash related to pressing on the terminal notification. Rather than start a new terminal activity through an intent, bring the previous terminal activity to the front.

This will allow the user a one click process to get back to where they previously were in the terminal.



**Link to relevant issues**
#506 
(Current PR has a cleaner git history)