### PR TITLE
Add delay to ensure coroutine fires.

### DIFF
--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -4,6 +4,7 @@ import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.* // ktlint-disable no-wildcard-imports
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -82,6 +83,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.waitForPermissions(appToContinue = selectedApp)
         mainActivityViewModel.permissionsHaveBeenGranted()
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp))
         }
     }
@@ -91,6 +93,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.waitForPermissions(sessionToContinue = selectedSession)
         mainActivityViewModel.permissionsHaveBeenGranted()
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession))
         }
     }
@@ -119,6 +122,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitSessionSelection(selectedSession)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
             verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession))
         }
@@ -132,6 +136,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitSessionSelection(selectedSession)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
             verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession))
         }
@@ -143,6 +148,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitAppSelection(selectedApp)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp))
         }
     }
@@ -153,6 +159,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitSessionSelection(selectedSession)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession))
         }
     }
@@ -162,6 +169,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitCompletedDownloadId(1)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(AssetDownloadComplete(1))
         }
     }
@@ -183,6 +191,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitFilesystemCredentials(username, password, vncPassword)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(SubmitAppsFilesystemCredentials(selectedFilesystem, username, password, vncPassword))
         }
     }
@@ -201,6 +210,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitAppServicePreference(SshTypePreference)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(SubmitAppServicePreference(selectedApp, SshTypePreference))
         }
     }
@@ -218,6 +228,7 @@ class MainActivityViewModelTest {
         assertEquals(mainActivityViewModel.lastSelectedFilesystem, unselectedFilesystem)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState)
         }
@@ -230,6 +241,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.startAssetDownloads(downloads)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads))
         }
     }
@@ -277,6 +289,7 @@ class MainActivityViewModelTest {
         assertEquals(selectedSession, mainActivityViewModel.lastSelectedSession)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(CheckAppsFilesystemCredentials(selectedFilesystem))
         }
     }
@@ -297,6 +310,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(AppsFilesystemHasCredentials)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(CheckAppServicePreference(selectedApp))
         }
     }
@@ -317,6 +331,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(AppHasServiceTypePreferenceSet)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(CopyAppScriptToFilesystem(selectedApp, selectedFilesystem))
         }
     }
@@ -337,6 +352,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(AppScriptCopySucceeded)
 
         runBlocking {
+            delay(1)
             verify(mockAppsStartupFsm).submitEvent(SyncDatabaseEntries(selectedApp, selectedSession, selectedFilesystem))
         }
     }
@@ -362,6 +378,7 @@ class MainActivityViewModelTest {
         assertEquals(updatedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(SessionSelected(updatedSession))
         }
     }
@@ -412,6 +429,7 @@ class MainActivityViewModelTest {
 
         verify(mockStateObserver).onChanged(StartingSetup)
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(RetrieveAssetLists(selectedFilesystem))
         }
     }
@@ -433,6 +451,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AssetListsRetrievalSucceeded(assetLists))
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(GenerateDownloads(selectedFilesystem, assetLists))
         }
     }
@@ -473,6 +492,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(DownloadsRequired(downloads, largeDownloadRequired = false))
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads))
         }
     }
@@ -484,6 +504,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(NoDownloadsRequired)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem))
         }
     }
@@ -504,6 +525,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(DownloadsHaveSucceeded)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(CopyDownloadsToLocalStorage)
         }
     }
@@ -534,6 +556,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(CopyingSucceeded)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem))
         }
     }
@@ -573,6 +596,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(ExtractionSucceeded)
 
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(VerifyFilesystemAssets(selectedFilesystem))
         }
     }
@@ -606,6 +630,7 @@ class MainActivityViewModelTest {
         assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
         assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
         runBlocking {
+            delay(1)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState)
         }


### PR DESCRIPTION
**Describe the pull request**

This adds a slight delay to the tests of the main VM so that the coroutine launched to move state machine work off the main android thread has a chance to fire before the test ends.

**Link to relevant issues**
N/A