### PR TITLE
Reduce animations in Apps List Page

### DIFF
--- a/app/src/main/java/tech/ula/ui/AppListAdapter.kt
+++ b/app/src/main/java/tech/ula/ui/AppListAdapter.kt
@@ -227,13 +227,16 @@ class AppsListDiffCallBack(
                 return true
             }
         } else if (oldApp is AppItem && newApp is AppItem) {
+            val oldAppIsActive = oldActiveApps.contains(oldApp.app)
+            val newAppIsActive = newActiveApps.contains(newApp.app)
             if (oldApp.app.category == newApp.app.category &&
                     oldApp.app.name == newApp.app.name &&
                     oldApp.app.version == newApp.app.version &&
                     oldApp.app.filesystemRequired == newApp.app.filesystemRequired &&
                     oldApp.app.isPaidApp == newApp.app.isPaidApp &&
                     oldApp.app.supportsCli == newApp.app.supportsCli &&
-                    oldApp.app.supportsGui == newApp.app.supportsGui) {
+                    oldApp.app.supportsGui == newApp.app.supportsGui &&
+                    oldAppIsActive == newAppIsActive) {
                 return true
             }
         }


### PR DESCRIPTION
**Describe the pull request**

Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.

Reduces the animations on the Apps list page each time the activity is shown.

Only runs the animations on the first time it is run or if an app list item is updated.



## First time app is loaded
 Subsequent taps to go back to the apps page will not show animations

![1](https://media.giphy.com/media/8FiLGDUVKvyTperD63/giphy.gif)



## Changes to one app list item
Only one item will animate if change in list is detected

![2](https://media.giphy.com/media/fQABpqhumcW13tse8Y/giphy.gif)

