### PR TITLE
Fix #537

### DIFF
--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -207,7 +207,7 @@ class MainActivityViewModel(
     }
 
     private fun handleSessionPreparationState(newState: SessionStartupState) {
-        if (!sessionPreparationRequirementsHaveBeenSelected() && newState !is WaitingForSessionSelection) {
+        if (!sessionPreparationRequirementsHaveBeenSelected() && newState !is WaitingForSessionSelection && newState !is SessionIsRestartable) {
             state.postValue(NoSessionSelectedWhenPreparationStarted)
             return
         }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -75,6 +75,14 @@ class MainActivityViewModel(
                     lastSelectedSession = update.session
                     lastSelectedFilesystem = update.filesystem
                 }
+                is SessionIsRestartable -> {
+                    state.postValue(SessionCanBeRestarted(update.session))
+                    resetStartupState()
+                }
+                is SingleSessionSupported -> {
+                    state.postValue(CanOnlyStartSingleSession)
+                    resetStartupState()
+                }
             }
             handleSessionPreparationState(update)
         } }
@@ -163,7 +171,11 @@ class MainActivityViewModel(
     }
 
     private fun handleAppsPreparationState(newState: AppsStartupState) {
-        if (!appsPreparationRequirementsHaveBeenSelected() && newState !is WaitingForAppSelection && newState !is FetchingDatabaseEntries) {
+        // Exit early if we aren't expecting preparation requirements to have been met
+        if (newState is WaitingForAppSelection || newState is FetchingDatabaseEntries) {
+            return
+        }
+        if (!appsPreparationRequirementsHaveBeenSelected()) {
             state.postValue(NoAppSelectedWhenPreparationStarted)
             return
         }
@@ -172,7 +184,7 @@ class MainActivityViewModel(
             is IncorrectAppTransition -> {
                 state.postValue(IllegalStateTransition("$newState"))
             }
-            is WaitingForAppSelection -> { }
+            is WaitingForAppSelection -> {}
             is FetchingDatabaseEntries -> {}
             is DatabaseEntriesFetched -> {
                 submitAppsStartupEvent(CheckAppsFilesystemCredentials(lastSelectedFilesystem))
@@ -207,7 +219,12 @@ class MainActivityViewModel(
     }
 
     private fun handleSessionPreparationState(newState: SessionStartupState) {
-        if (!sessionPreparationRequirementsHaveBeenSelected() && newState !is WaitingForSessionSelection && newState !is SessionIsRestartable) {
+        // Exit early if we aren't expecting preparation requirements to have been met
+        if (newState is WaitingForSessionSelection || newState is SingleSessionSupported ||
+                newState is SessionIsRestartable) {
+            return
+        }
+        if (!sessionPreparationRequirementsHaveBeenSelected()) {
             state.postValue(NoSessionSelectedWhenPreparationStarted)
             return
         }
@@ -217,14 +234,8 @@ class MainActivityViewModel(
                 state.postValue(IllegalStateTransition("$newState"))
             }
             is WaitingForSessionSelection -> {}
-            is SingleSessionSupported -> {
-                state.postValue(CanOnlyStartSingleSession)
-                resetStartupState()
-            }
-            is SessionIsRestartable -> {
-                state.postValue(SessionCanBeRestarted(newState.session))
-                resetStartupState()
-            }
+            is SingleSessionSupported -> {}
+            is SessionIsRestartable -> {}
             is SessionIsReadyForPreparation -> {
                 state.postValue(StartingSetup)
                 submitSessionStartupEvent(RetrieveAssetLists(lastSelectedFilesystem))

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -428,7 +428,7 @@ class MainActivityViewModelTest {
 
     @Test
     fun `Posts IllegalState if session preparation event is observed that is not WaitingForSelection and prep reqs have not been met`() {
-        sessionStartupStateLiveData.postValue(SingleSessionSupported)
+        sessionStartupStateLiveData.postValue(NoDownloadsRequired)
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenPreparationStarted)
     }


### PR DESCRIPTION
**Describe the pull request**

This fixes #537.

The illegal state was occuring because the mainvm was attempting to launch into session preparation for states that it did not need to. When preparing sessions, a filesystem is normally selected to accompany the session, and this wasn't part of the states causing the issue.

**Link to relevant issues**

Resolves #537.
