### PR TITLE
Use ids to track downloads and throw exceptions on illegal state.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 41
-        versionName "2.2.1"
+        versionCode 42
+        versionName "2.2.2"
         
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/release/output.json
+++ b/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":41,"versionName":"2.2.1","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":42,"versionName":"2.2.2","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -49,6 +49,7 @@ import tech.ula.ui.AppListFragment
 import tech.ula.ui.SessionListFragment
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
+import java.lang.IllegalStateException
 
 class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection {
 
@@ -345,6 +346,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 .setPositiveButton(R.string.button_ok) {
                     dialog, _ ->
                     dialog.dismiss()
+                    throw IllegalStateException(reason)
                 }
                 .create().show()
     }

--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -11,8 +11,9 @@ class DownloadUtility(
 
     private val downloadDirectory = downloadManagerWrapper.getDownloadsDirectory()
 
-    fun downloadRequirements(assetList: List<Asset>): List<Pair<Asset, Long>> {
-        return assetList.map { it to download(it) }
+    fun downloadRequirements(assetList: List<Asset>): List<Long> {
+        clearPreviousDownloadsFromDownloadsDirectory()
+        return assetList.map { download(it) }
     }
 
     fun downloadedSuccessfully(id: Long): Boolean {
@@ -32,17 +33,21 @@ class DownloadUtility(
                 "${asset.architectureType}/${asset.name}"
         val destination = asset.concatenatedName
         val request = downloadManagerWrapper.generateDownloadRequest(url, destination)
-        deletePreviousDownload(asset)
-
+        deletePreviousDownloadFromLocalDirectory(asset)
         return downloadManagerWrapper.enqueue(request)
     }
 
-    private fun deletePreviousDownload(asset: Asset) {
-        val downloadsDirectoryFile = File(downloadDirectory, asset.concatenatedName)
+    private fun clearPreviousDownloadsFromDownloadsDirectory() {
+        for (file in downloadDirectory.listFiles()) {
+            if (file.name.toLowerCase().contains("userland")) {
+                file.delete()
+            }
+        }
+    }
+
+    private fun deletePreviousDownloadFromLocalDirectory(asset: Asset) {
         val localFile = File(applicationFilesDir, asset.pathName)
 
-        if (downloadsDirectoryFile.exists())
-            downloadsDirectoryFile.delete()
         if (localFile.exists())
             localFile.delete()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="error_vnc_password_invalid">VNC Password has invalid characters</string>
 
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \nPlease restart the app and contact a developer.</string>
+    <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>
     <string name="illegal_state_title">UserLAnd has entered an illegal state!</string>
 
     <string name="illegal_state_transition">Bad state transition: %1$s</string>

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -313,7 +313,7 @@ class SessionStartupFsmTest {
         sessionFsm.getState().observeForever(mockStateObserver)
 
         whenever(mockDownloadUtility.downloadRequirements(downloadList))
-                .thenReturn(listOf(Pair(asset, 0L), Pair(largeAsset, 1L)))
+                .thenReturn(listOf(0L, 1L))
         whenever(mockDownloadUtility.downloadedSuccessfully(0))
                 .thenReturn(true)
         whenever(mockDownloadUtility.downloadedSuccessfully(1))
@@ -339,7 +339,7 @@ class SessionStartupFsmTest {
         sessionFsm.getState().observeForever(mockStateObserver)
 
         whenever(mockDownloadUtility.downloadRequirements(downloadList))
-                .thenReturn(listOf(Pair(asset, 0L), Pair(largeAsset, 1L)))
+                .thenReturn(listOf(0L, 1L))
         whenever(mockDownloadUtility.downloadedSuccessfully(0))
                 .thenReturn(true)
         whenever(mockDownloadUtility.downloadedSuccessfully(1))

--- a/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
@@ -71,6 +71,21 @@ class DownloadUtilityTest {
     }
 
     @Test
+    fun `Clears download directory of userland files`() {
+        val asset1DownloadsFile = File("${downloadDirectory.path}/${asset1.concatenatedName}")
+        val asset2DownloadsFile = File("${downloadDirectory.path}/${asset2.concatenatedName}")
+        asset1DownloadsFile.createNewFile()
+        asset2DownloadsFile.createNewFile()
+        assertTrue(asset1DownloadsFile.exists())
+        assertTrue(asset2DownloadsFile.exists())
+
+        downloadUtility.downloadRequirements(assetList)
+
+        assertFalse(asset1DownloadsFile.exists())
+        assertFalse(asset2DownloadsFile.exists())
+    }
+
+    @Test
     fun deletesPreviousDownloads() {
         tempFolder.newFolder("distType1")
         tempFolder.newFolder("distType2")


### PR DESCRIPTION
**Describe the pull request**

This will use download ids to track whether downloads have completed, instead of just relying on size of enqueued downloads and received downloads. Also clears the downloads directory of userland files prior to downloading. 

Getting into illegal state will now cause an app crash so that we can receive stack trace logs in the developer console. This is intended for beta only and will be removed for the next production release.

**Link to relevant issues**
#538 #539 #486