### PR TITLE
Fix mainvm tests

### DIFF
--- a/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
@@ -2,7 +2,9 @@ package tech.ula.model.state
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tech.ula.model.entities.App
 import tech.ula.model.entities.Filesystem
@@ -45,14 +47,14 @@ class AppsStartupFsm(
         }
     }
 
-    suspend fun submitEvent(event: AppsStartupEvent) {
+    fun submitEvent(event: AppsStartupEvent, coroutineScope: CoroutineScope) = coroutineScope.launch {
         crashlyticsWrapper.setString("Last submitted apps fsm event", "$event")
         crashlyticsWrapper.setString("State during apps fsm event submission", "${state.value}")
         if (!transitionIsAcceptable(event)) {
             state.postValue(IncorrectAppTransition(event, state.value!!))
-            return
+            return@launch
         }
-        return when (event) {
+        return@launch when (event) {
             is AppSelected -> fetchDatabaseEntries(event.app)
             is CheckAppsFilesystemCredentials -> checkAppsFilesystemCredentials(event.appsFilesystem)
             is SubmitAppsFilesystemCredentials -> {

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -2,7 +2,9 @@ package tech.ula.model.state
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem
@@ -83,12 +85,12 @@ class SessionStartupFsm(
         }
     }
 
-    suspend fun submitEvent(event: SessionStartupEvent) {
+    fun submitEvent(event: SessionStartupEvent, coroutineScope: CoroutineScope) = coroutineScope.launch {
         crashlyticsWrapper.setString("Last submitted session fsm event", "$event")
         crashlyticsWrapper.setString("State during session fsm event submission", "${state.value}")
         if (!transitionIsAcceptable(event)) {
             state.postValue(IncorrectSessionTransition(event, state.value!!))
-            return
+            return@launch
         }
         when (event) {
             is SessionSelected -> { handleSessionSelected(event.session) }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -40,8 +40,14 @@ class MainActivityViewModel(
 
     private val state = MediatorLiveData<State>()
 
+    private val job = Job()
     override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + Job()
+        get() = Dispatchers.Main + job
+
+    override fun onCleared() {
+        super.onCleared()
+        job.cancel()
+    }
 
     init {
         state.addSource(appsState) { it?.let { update ->

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -4,7 +4,10 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
 import tech.ula.model.entities.App
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -332,8 +332,7 @@ class MainActivityViewModel(
 
     private fun submitAppsStartupEvent(event: AppsStartupEvent) {
         crashlyticsWrapper.setString("Last viewmodel apps event submission", "$event")
-        val coroutineScope = CoroutineScope(Dispatchers.Default)
-        coroutineScope.launch { appsStartupFsm.submitEvent(event) }
+        appsStartupFsm.submitEvent(event, this)
     }
 
     private fun submitSessionStartupEvent(event: SessionStartupEvent) {

--- a/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
@@ -127,7 +127,7 @@ class AppsStartupFsmTest {
         appsFsm.getState().observeForever(mockStateObserver)
 
         val event = CheckAppsFilesystemCredentials(appsFilesystem)
-        runBlocking { appsFsm.submitEvent(event) }
+        runBlocking { appsFsm.submitEvent(event, this) }
 
         verify(mockStateObserver).onChanged(IncorrectAppTransition(event, state))
         verify(mockStateObserver, times(2)).onChanged(any())
@@ -147,7 +147,7 @@ class AppsStartupFsmTest {
 
         for (state in possibleStates) {
             appsFsm.setState(state)
-            runBlocking { appsFsm.submitEvent(ResetAppState) }
+            runBlocking { appsFsm.submitEvent(ResetAppState, this) }
         }
 
         val numberOfStates = possibleStates.size
@@ -168,7 +168,7 @@ class AppsStartupFsmTest {
                 .thenReturn(listOf())
                 .thenReturn(listOf(appsFilesystem))
 
-        runBlocking { appsFsm.submitEvent(AppSelected(app)) }
+        runBlocking { appsFsm.submitEvent(AppSelected(app), this) }
 
         verify(mockStateObserver).onChanged(FetchingDatabaseEntries)
         verify(mockStateObserver).onChanged(DatabaseEntriesFetched(appsFilesystem, appSession))
@@ -187,7 +187,7 @@ class AppsStartupFsmTest {
                 .thenReturn(listOf())
                 .thenReturn(listOf(appSession))
 
-        runBlocking { appsFsm.submitEvent(AppSelected(app)) }
+        runBlocking { appsFsm.submitEvent(AppSelected(app), this) }
 
         verify(mockStateObserver).onChanged(FetchingDatabaseEntries)
         verify(mockStateObserver).onChanged(DatabaseEntriesFetched(appsFilesystem, appSession))
@@ -205,7 +205,7 @@ class AppsStartupFsmTest {
         whenever(mockSessionDao.findAppsSession(app.name))
                 .thenReturn(listOf(appSession))
 
-        runBlocking { appsFsm.submitEvent(AppSelected(app)) }
+        runBlocking { appsFsm.submitEvent(AppSelected(app), this) }
 
         verify(mockStateObserver).onChanged(FetchingDatabaseEntries)
         verify(mockStateObserver).onChanged(DatabaseEntriesFetched(appsFilesystem, appSession))
@@ -222,7 +222,7 @@ class AppsStartupFsmTest {
                 .thenReturn(listOf())
                 .thenReturn(listOf()) // Simulate failure to retrieve previous insertion
 
-        runBlocking { appsFsm.submitEvent(AppSelected(app)) }
+        runBlocking { appsFsm.submitEvent(AppSelected(app), this) }
 
         verify(mockFilesystemDao, times(2)).findAppsFilesystemByType(app.filesystemRequired)
         verify(mockFilesystemDao).insertFilesystem(appsFilesystem)
@@ -237,7 +237,7 @@ class AppsStartupFsmTest {
 
         val filesystemWithoutUsername = appsFilesystemWithCredentials
         filesystemWithoutUsername.defaultUsername = ""
-        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutUsername)) }
+        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutUsername), this) }
 
         verify(mockStateObserver).onChanged(AppsFilesystemRequiresCredentials(filesystemWithoutUsername))
     }
@@ -249,7 +249,7 @@ class AppsStartupFsmTest {
 
         val filesystemWithoutPassword = appsFilesystemWithCredentials
         filesystemWithoutPassword.defaultPassword = ""
-        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutPassword)) }
+        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutPassword), this) }
 
         verify(mockStateObserver).onChanged(AppsFilesystemRequiresCredentials(filesystemWithoutPassword))
     }
@@ -261,7 +261,7 @@ class AppsStartupFsmTest {
 
         val filesystemWithoutVncPassword = appsFilesystemWithCredentials
         filesystemWithoutVncPassword.defaultVncPassword = ""
-        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutVncPassword)) }
+        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(filesystemWithoutVncPassword), this) }
 
         verify(mockStateObserver).onChanged(AppsFilesystemRequiresCredentials(filesystemWithoutVncPassword))
     }
@@ -271,7 +271,7 @@ class AppsStartupFsmTest {
         appsFsm.setState(DatabaseEntriesFetched(appsFilesystem, appSession))
         appsFsm.getState().observeForever(mockStateObserver)
 
-        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(appsFilesystemWithCredentials)) }
+        runBlocking { appsFsm.submitEvent(CheckAppsFilesystemCredentials(appsFilesystemWithCredentials), this) }
 
         verify(mockStateObserver).onChanged(AppsFilesystemHasCredentials)
     }
@@ -281,7 +281,7 @@ class AppsStartupFsmTest {
         appsFsm.setState(AppsFilesystemRequiresCredentials(appsFilesystem))
         appsFsm.getState().observeForever(mockStateObserver)
 
-        runBlocking { appsFsm.submitEvent(SubmitAppsFilesystemCredentials(appsFilesystem, defaultUsername, defaultPassword, defaultPassword)) }
+        runBlocking { appsFsm.submitEvent(SubmitAppsFilesystemCredentials(appsFilesystem, defaultUsername, defaultPassword, defaultPassword), this) }
 
         verify(mockFilesystemDao).updateFilesystem(appsFilesystemWithCredentials)
         verify(mockStateObserver).onChanged(AppsFilesystemHasCredentials)
@@ -295,7 +295,7 @@ class AppsStartupFsmTest {
         whenever(mockAppsPreferences.getAppServiceTypePreference(app))
                 .thenReturn(SshTypePreference)
 
-        runBlocking { appsFsm.submitEvent(CheckAppServicePreference(app)) }
+        runBlocking { appsFsm.submitEvent(CheckAppServicePreference(app), this) }
 
         verify(mockStateObserver).onChanged(AppHasServiceTypePreferenceSet)
     }
@@ -308,7 +308,7 @@ class AppsStartupFsmTest {
         whenever(mockAppsPreferences.getAppServiceTypePreference(app))
                 .thenReturn(PreferenceHasNotBeenSelected)
 
-        runBlocking { appsFsm.submitEvent(CheckAppServicePreference(app)) }
+        runBlocking { appsFsm.submitEvent(CheckAppServicePreference(app), this) }
 
         verify(mockStateObserver).onChanged(AppRequiresServiceTypePreference)
     }
@@ -318,7 +318,7 @@ class AppsStartupFsmTest {
         appsFsm.setState(AppRequiresServiceTypePreference)
         appsFsm.getState().observeForever(mockStateObserver)
 
-        runBlocking { appsFsm.submitEvent(SubmitAppServicePreference(app, SshTypePreference)) }
+        runBlocking { appsFsm.submitEvent(SubmitAppServicePreference(app, SshTypePreference), this) }
 
         verify(mockAppsPreferences).setAppServiceTypePreference(app.name, SshTypePreference)
         verify(mockStateObserver).onChanged(AppHasServiceTypePreferenceSet)
@@ -329,7 +329,7 @@ class AppsStartupFsmTest {
         appsFsm.setState(AppHasServiceTypePreferenceSet)
         appsFsm.getState().observeForever(mockStateObserver)
 
-        runBlocking { appsFsm.submitEvent(CopyAppScriptToFilesystem(app, appsFilesystem)) }
+        runBlocking { appsFsm.submitEvent(CopyAppScriptToFilesystem(app, appsFilesystem), this) }
 
         verify(mockStateObserver).onChanged(CopyingAppScript)
         verify(mockStateObserver).onChanged(AppScriptCopySucceeded)
@@ -343,7 +343,7 @@ class AppsStartupFsmTest {
         whenever(mockFilesystemUtility.moveAppScriptToRequiredLocation(app.name, appsFilesystem))
                 .thenThrow(Exception())
 
-        runBlocking { appsFsm.submitEvent(CopyAppScriptToFilesystem(app, appsFilesystem)) }
+        runBlocking { appsFsm.submitEvent(CopyAppScriptToFilesystem(app, appsFilesystem), this) }
 
         verify(mockStateObserver).onChanged(CopyingAppScript)
         verify(mockStateObserver).onChanged(AppScriptCopyFailed)
@@ -357,7 +357,7 @@ class AppsStartupFsmTest {
         whenever(mockAppsPreferences.getAppServiceTypePreference(app))
                 .thenReturn(SshTypePreference)
 
-        runBlocking { appsFsm.submitEvent(SyncDatabaseEntries(app, appSession, appsFilesystemWithCredentials)) }
+        runBlocking { appsFsm.submitEvent(SyncDatabaseEntries(app, appSession, appsFilesystemWithCredentials), this) }
 
         val updatedAppSession = appSession
         updatedAppSession.filesystemId = appsFilesystemWithCredentials.id
@@ -381,7 +381,7 @@ class AppsStartupFsmTest {
         whenever(mockAppsPreferences.getAppServiceTypePreference(app))
                 .thenReturn(VncTypePreference)
 
-        runBlocking { appsFsm.submitEvent(SyncDatabaseEntries(app, appSession, appsFilesystemWithCredentials)) }
+        runBlocking { appsFsm.submitEvent(SyncDatabaseEntries(app, appSession, appsFilesystemWithCredentials), this) }
 
         val updatedAppSession = appSession
         updatedAppSession.filesystemId = appsFilesystemWithCredentials.id

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -4,9 +4,6 @@ import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.* // ktlint-disable no-wildcard-imports
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.* // ktlint-disable no-wildcard-imports

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -92,7 +92,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.permissionsHaveBeenGranted()
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp))
+            verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp), mainActivityViewModel)
         }
     }
 
@@ -131,7 +131,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
+            verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp), mainActivityViewModel)
             verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
@@ -145,7 +145,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
+            verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp), mainActivityViewModel)
             verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
@@ -157,7 +157,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp))
+            verify(mockAppsStartupFsm).submitEvent(AppSelected(selectedApp), mainActivityViewModel)
         }
     }
 
@@ -200,7 +200,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(SubmitAppsFilesystemCredentials(selectedFilesystem, username, password, vncPassword))
+            verify(mockAppsStartupFsm).submitEvent(SubmitAppsFilesystemCredentials(selectedFilesystem, username, password, vncPassword), mainActivityViewModel)
         }
     }
 
@@ -219,7 +219,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(SubmitAppServicePreference(selectedApp, SshTypePreference))
+            verify(mockAppsStartupFsm).submitEvent(SubmitAppServicePreference(selectedApp, SshTypePreference), mainActivityViewModel)
         }
     }
 
@@ -237,7 +237,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(ResetAppState)
+            verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
         }
     }
@@ -336,7 +336,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(CheckAppsFilesystemCredentials(selectedFilesystem))
+            verify(mockAppsStartupFsm).submitEvent(CheckAppsFilesystemCredentials(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -357,7 +357,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(CheckAppServicePreference(selectedApp))
+            verify(mockAppsStartupFsm).submitEvent(CheckAppServicePreference(selectedApp), mainActivityViewModel)
         }
     }
 
@@ -378,7 +378,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(CopyAppScriptToFilesystem(selectedApp, selectedFilesystem))
+            verify(mockAppsStartupFsm).submitEvent(CopyAppScriptToFilesystem(selectedApp, selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -399,7 +399,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockAppsStartupFsm).submitEvent(SyncDatabaseEntries(selectedApp, selectedSession, selectedFilesystem))
+            verify(mockAppsStartupFsm).submitEvent(SyncDatabaseEntries(selectedApp, selectedSession, selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -678,7 +678,7 @@ class MainActivityViewModelTest {
         runBlocking {
             delay(delayForCoroutineLaunch)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
-            verify(mockAppsStartupFsm).submitEvent(ResetAppState)
+            verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
         }
     }
 

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -54,7 +54,7 @@ class MainActivityViewModelTest {
 
     private lateinit var mainActivityViewModel: MainActivityViewModel
 
-    private val delayForCoroutineLaunch = 2L
+    private val delayForCoroutineLaunch = 0L
 
     private fun makeAppSelections() {
         mainActivityViewModel.lastSelectedApp = selectedApp
@@ -102,7 +102,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.permissionsHaveBeenGranted()
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession))
+            verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
 
@@ -132,7 +132,7 @@ class MainActivityViewModelTest {
         runBlocking {
             delay(delayForCoroutineLaunch)
             verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
-            verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession))
+            verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
 
@@ -146,7 +146,7 @@ class MainActivityViewModelTest {
         runBlocking {
             delay(delayForCoroutineLaunch)
             verify(mockAppsStartupFsm, never()).submitEvent(AppSelected(selectedApp))
-            verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession))
+            verify(mockSessionStartupFsm, never()).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
 
@@ -168,7 +168,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession))
+            verify(mockSessionStartupFsm).submitEvent(SessionSelected(selectedSession), mainActivityViewModel)
         }
     }
 
@@ -178,7 +178,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(AssetDownloadComplete(1))
+            verify(mockSessionStartupFsm).submitEvent(AssetDownloadComplete(1), mainActivityViewModel)
         }
     }
 
@@ -238,7 +238,7 @@ class MainActivityViewModelTest {
         runBlocking {
             delay(delayForCoroutineLaunch)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState)
-            verify(mockSessionStartupFsm).submitEvent(ResetSessionState)
+            verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
         }
     }
 
@@ -250,7 +250,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads))
+            verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads), mainActivityViewModel)
         }
     }
 
@@ -425,7 +425,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(SessionSelected(updatedSession))
+            verify(mockSessionStartupFsm).submitEvent(SessionSelected(updatedSession), mainActivityViewModel)
         }
     }
 
@@ -476,7 +476,7 @@ class MainActivityViewModelTest {
         verify(mockStateObserver).onChanged(StartingSetup)
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(RetrieveAssetLists(selectedFilesystem))
+            verify(mockSessionStartupFsm).submitEvent(RetrieveAssetLists(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -498,7 +498,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(GenerateDownloads(selectedFilesystem, assetLists))
+            verify(mockSessionStartupFsm).submitEvent(GenerateDownloads(selectedFilesystem, assetLists), mainActivityViewModel)
         }
     }
 
@@ -539,7 +539,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads))
+            verify(mockSessionStartupFsm).submitEvent(DownloadAssets(downloads), mainActivityViewModel)
         }
     }
 
@@ -551,7 +551,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem))
+            verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -572,7 +572,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(CopyDownloadsToLocalStorage(selectedFilesystem))
+            verify(mockSessionStartupFsm).submitEvent(CopyDownloadsToLocalStorage(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -603,7 +603,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem))
+            verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -643,7 +643,7 @@ class MainActivityViewModelTest {
 
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(VerifyFilesystemAssets(selectedFilesystem))
+            verify(mockSessionStartupFsm).submitEvent(VerifyFilesystemAssets(selectedFilesystem), mainActivityViewModel)
         }
     }
 
@@ -677,7 +677,7 @@ class MainActivityViewModelTest {
         assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
         runBlocking {
             delay(delayForCoroutineLaunch)
-            verify(mockSessionStartupFsm).submitEvent(ResetSessionState)
+            verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState)
         }
     }


### PR DESCRIPTION
**Describe the pull request**

This PR should solve the issue of randomly failing `MainActivityViewModel` tests. Those tests would fail because they were reliant on verifying that events had been submitted to the apps and sessions finite state machines. Submitting events must be done in a coroutine, as they often lead to tasks that can not be handled on Android's main thread (such as network I/O). Previously, the viewmodel would just launch a coroutine every time it submitted an event. This caused random failures because there was no way to guarantee the coroutine had launched before attempted to verify FSM mock interactions.

This is solved by implementing `CoroutineScope` with the viewmodel, injecting that scope into the FSM when events are submitted, and then using the injected scope to launch the coroutine from the FSM itself. This allows tests of the viewmodel to not rely on coroutines at all, and allows tests of the FSMs to inject `runBlocking` scope which will then block execution until all coroutines launched within it have completed.

This will also have the benefit of ensuring that we never leak coroutines if the viewmodel is cleared while one launched from it is running.

**Link to relevant issues**
N/A
