### PR TITLE
Toggle password visibility

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -18,6 +18,8 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.support.design.widget.TextInputEditText
+import android.support.design.widget.TextInputLayout
 import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
@@ -584,9 +586,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
         customDialog.setOnShowListener { _ ->
             customDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener { _ ->
-                val username = customDialog.find<EditText>(R.id.text_input_username).text.toString()
-                val password = customDialog.find<EditText>(R.id.text_input_password).text.toString()
-                val vncPassword = customDialog.find<EditText>(R.id.text_input_vnc_password).text.toString()
+                val username = customDialog.find<TextInputEditText>(R.id.text_input_username).text.toString()
+                val password = customDialog.find<TextInputEditText>(R.id.text_input_password).text.toString()
+                val vncPassword = customDialog.find<TextInputEditText>(R.id.text_input_vnc_password).text.toString()
 
                 if (validateCredentials(username, password, vncPassword)) {
                     customDialog.dismiss()

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -19,14 +19,12 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.support.design.widget.TextInputEditText
-import android.support.design.widget.TextInputLayout
 import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.animation.AlphaAnimation
-import android.widget.EditText
 import android.widget.RadioButton
 import android.widget.TextView
 import android.widget.Toast

--- a/app/src/main/res/layout/dia_app_credentials.xml
+++ b/app/src/main/res/layout/dia_app_credentials.xml
@@ -14,78 +14,75 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
+            android:padding="8dp"
             android:text="@string/filesystem_credentials_reasoning"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 
-        <TextView
-            android:id="@+id/text_title_username"
-            android:layout_width="wrap_content"
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/text_input_layout_username"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/hint_username"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_filesystem_credentials_reasoning" />
-
-        <EditText
-            android:id="@+id/text_input_username"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginTop="8dp"
-            android:ems="10"
-            android:hint="@string/hint_username"
+            android:layout_marginEnd="16dp"
             android:inputType="textNoSuggestions|textVisiblePassword"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/text_title_username"
-            app:layout_constraintTop_toBottomOf="@+id/text_title_username" />
+            app:layout_constraintTop_toBottomOf="@+id/text_filesystem_credentials_reasoning">
 
-        <TextView
-            android:id="@+id/text_title_password"
-            android:layout_width="wrap_content"
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/text_input_username"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:inputType="text"
+                android:hint="@string/hint_username" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/text_input_layout_password"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:passwordToggleEnabled="true"
             android:layout_marginTop="16dp"
-            android:text="@string/hint_password"
-            app:layout_constraintStart_toStartOf="@+id/text_title_username"
-            app:layout_constraintTop_toBottomOf="@+id/text_input_username" />
-
-        <EditText
-            android:id="@+id/text_input_password"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginTop="8dp"
-            android:ems="10"
-            android:hint="@string/hint_password"
-            android:inputType="textPassword"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/text_title_username"
-            app:layout_constraintTop_toBottomOf="@+id/text_title_password" />
+            app:layout_constraintTop_toBottomOf="@+id/text_input_layout_username">
 
-        <TextView
-            android:id="@+id/text_title_vnc_password"
-            android:layout_width="wrap_content"
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/text_input_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/hint_password"
+                android:inputType="textPassword" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/text_input_layout_vnc_password"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:passwordToggleEnabled="true"
             android:layout_marginTop="16dp"
-            android:text="@string/hint_vnc_password"
-            app:layout_constraintStart_toStartOf="@+id/text_title_username"
-            app:layout_constraintTop_toBottomOf="@+id/text_input_password" />
-
-        <EditText
-            android:id="@+id/text_input_vnc_password"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginTop="8dp"
-            android:ems="10"
-            android:hint="@string/hint_vnc_password"
-            android:inputType="textPassword"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/text_title_username"
-            app:layout_constraintTop_toBottomOf="@+id/text_title_vnc_password" />
+            app:layout_constraintTop_toBottomOf="@+id/text_input_layout_password">
 
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/text_input_vnc_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="@string/hint_vnc_password"
+                android:inputType="textPassword" />
+        </android.support.design.widget.TextInputLayout>
 
     </android.support.constraint.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="button_ok">OK!</string>
     <string name="button_cancel">Cancel</string>
     <string name="general_error_title">Something unexpected happened!</string>
-    <string name="filesystem_credentials_reasoning">We\'re creating a filesystem for your apps.Please enter the relevant required information for us to use as defaults for this filesystem.</string>
+    <string name="filesystem_credentials_reasoning">We\'re creating a filesystem for your apps.\nPlease enter the relevant required information for us to use as defaults for this filesystem.</string>
     <string name="deactivate_sessions">All sessions need to be deactivated to continue this action.</string>
 
     <!-- Clear support files alert -->


### PR DESCRIPTION
**Describe the pull request**

The dialog for creating gathering user credentials will now have password fields that allow the ability to toggle it's visibility.  

Also added small UI improvements on text fields by following guide.  When pressing on the text field, the `hint` (placeholder text) will shrink and float above the field, which acts like a title.  [[1]](https://medium.theuxblog.com/10-best-practices-for-designing-user-friendly-forms-fa0ba7c3e01f)



![demo](https://media.giphy.com/media/oydx3za1c2QSZJgziP/giphy.gif)

[[1]  10 best practices for designing user friendly forms](https://medium.theuxblog.com/10-best-practices-for-designing-user-friendly-forms-fa0ba7c3e01f)

**Link to relevant issues**