### PR TITLE
Enable toggle password visibility in filesystem edit page.

### DIFF
--- a/app/src/main/res/layout/frag_filesystem_edit.xml
+++ b/app/src/main/res/layout/frag_filesystem_edit.xml
@@ -48,6 +48,7 @@
             android:layout_height="wrap_content"
             android:padding="8dp"
             android:hint="@string/hint_password"
+            app:passwordToggleEnabled="true"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_filesystem_username">
 
             <android.support.design.widget.TextInputEditText
@@ -64,6 +65,7 @@
             android:layout_height="wrap_content"
             android:padding="8dp"
             android:hint="@string/hint_vnc_password"
+            app:passwordToggleEnabled="true"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_filesystem_password">
 
             <android.support.design.widget.TextInputEditText


### PR DESCRIPTION
**Describe the pull request**

Can view the filesystem password and VNC password for an individual filesystem.

Go to the Filesystem tab, and long-press a filesystem to view its details.  Then press the 'eye' icon next to the password field.

![demo](https://media.giphy.com/media/kgSN6uehhGNdkS6a5h/giphy.gif)


**Link to relevant issues**
