### PR TITLE
Refactor filesystem credential validation

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -659,21 +659,27 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     }
 
     private fun validateCredentials(username: String, password: String, vncPassword: String): Boolean {
-        val resources = this.resources
-        val validator = ValidationUtility(resources)
-        var allCredentialsAreValid = false
+        val blacklistedUsernames = this.resources.getStringArray(R.array.blacklisted_usernames)
+        val validator = ValidationUtility(blacklistedUsernames)
 
         val usernameCredentials = validator.validateUsername(username)
-        val passwordCredentials = validator.validatePasswords(password, vncPassword)
+        val passwordCredentials = validator.validatePassword(password)
+        val vncPasswordCredentials = validator.validateVncPassword(vncPassword)
 
-        when {
-            !usernameCredentials.credentialIsValid ->
-                Toast.makeText(this, usernameCredentials.errorMessage, Toast.LENGTH_LONG).show()
-            !passwordCredentials.credentialIsValid ->
-                Toast.makeText(this, passwordCredentials.errorMessage, Toast.LENGTH_LONG).show()
-            else ->
-                allCredentialsAreValid = true
+        return when {
+            !usernameCredentials.credentialIsValid -> {
+                Toast.makeText(this, usernameCredentials.errorMessageId, Toast.LENGTH_LONG).show()
+                false
+            }
+            !passwordCredentials.credentialIsValid -> {
+                Toast.makeText(this, passwordCredentials.errorMessageId, Toast.LENGTH_LONG).show()
+                false
+            }
+            !vncPasswordCredentials.credentialIsValid -> {
+                Toast.makeText(this, passwordCredentials.errorMessageId, Toast.LENGTH_LONG).show()
+                false
+            }
+            else -> true
         }
-        return allCredentialsAreValid
     }
 }

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -658,31 +658,21 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         customDialog.show()
     }
 
-    // TODO the view shouldn't be responsible for validation
     private fun validateCredentials(username: String, password: String, vncPassword: String): Boolean {
-        val validator = ValidationUtility()
+        val resources = this.resources
+        val validator = ValidationUtility(resources)
         var allCredentialsAreValid = false
 
+        val usernameCredentials = validator.validateUsername(username)
+        val passwordCredentials = validator.validatePasswords(password, vncPassword)
+
         when {
-            username.isEmpty() || password.isEmpty() || vncPassword.isEmpty() -> {
-                Toast.makeText(this, R.string.error_empty_field, Toast.LENGTH_LONG).show()
-            }
-            vncPassword.length > 8 || vncPassword.length < 6 -> {
-                Toast.makeText(this, R.string.error_vnc_password_length_incorrect, Toast.LENGTH_LONG).show()
-            }
-            !validator.isUsernameValid(username) -> {
-                Toast.makeText(this, R.string.error_username_invalid, Toast.LENGTH_LONG).show()
-            }
-            !validator.isPasswordValid(password) -> {
-                Toast.makeText(this, R.string.error_password_invalid, Toast.LENGTH_LONG).show()
-            }
-            !validator.isPasswordValid(vncPassword) -> {
-                Toast.makeText(this, R.string.error_vnc_password_invalid, Toast.LENGTH_LONG).show()
-            }
-            else -> {
+            !usernameCredentials.credentialIsValid ->
+                Toast.makeText(this, usernameCredentials.errorMessage, Toast.LENGTH_LONG).show()
+            !passwordCredentials.credentialIsValid ->
+                Toast.makeText(this, passwordCredentials.errorMessage, Toast.LENGTH_LONG).show()
+            else ->
                 allCredentialsAreValid = true
-                return allCredentialsAreValid
-            }
         }
         return allCredentialsAreValid
     }

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -660,9 +660,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
     private fun validateCredentials(username: String, password: String, vncPassword: String): Boolean {
         val blacklistedUsernames = this.resources.getStringArray(R.array.blacklisted_usernames)
-        val validator = ValidationUtility(blacklistedUsernames)
+        val validator = ValidationUtility()
 
-        val usernameCredentials = validator.validateUsername(username)
+        val usernameCredentials = validator.validateUsername(username, blacklistedUsernames)
         val passwordCredentials = validator.validatePassword(password)
         val vncPasswordCredentials = validator.validateVncPassword(vncPassword)
 

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -181,7 +181,7 @@ class FilesystemEditFragment : Fragment() {
 
     private fun filesystemParametersAreCorrect(): Boolean {
         val blacklistedUsernames = activityContext.resources.getStringArray(R.array.blacklisted_usernames)
-        val validator = ValidationUtility(blacklistedUsernames)
+        val validator = ValidationUtility()
         val username = filesystem.defaultUsername
         val password = filesystem.defaultPassword
         val vncPassword = filesystem.defaultVncPassword
@@ -191,7 +191,7 @@ class FilesystemEditFragment : Fragment() {
             return false
         }
 
-        val usernameCredentials = validator.validateUsername(username)
+        val usernameCredentials = validator.validateUsername(username, blacklistedUsernames)
         val passwordCredentials = validator.validatePassword(password)
         val vncPasswordCredentials = validator.validateVncPassword(vncPassword)
 

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -180,7 +180,8 @@ class FilesystemEditFragment : Fragment() {
     }
 
     private fun filesystemParametersAreCorrect(): Boolean {
-        val validator = ValidationUtility(activityContext.resources)
+        val blacklistedUsernames = activityContext.resources.getStringArray(R.array.blacklisted_usernames)
+        val validator = ValidationUtility(blacklistedUsernames)
         val username = filesystem.defaultUsername
         val password = filesystem.defaultPassword
         val vncPassword = filesystem.defaultVncPassword
@@ -191,13 +192,16 @@ class FilesystemEditFragment : Fragment() {
         }
 
         val usernameCredentials = validator.validateUsername(username)
-        val passwordCredentials = validator.validatePasswords(password, vncPassword)
+        val passwordCredentials = validator.validatePassword(password)
+        val vncPasswordCredentials = validator.validateVncPassword(vncPassword)
 
         when {
             !usernameCredentials.credentialIsValid ->
-                Toast.makeText(activityContext, usernameCredentials.errorMessage, Toast.LENGTH_LONG).show()
+                Toast.makeText(activityContext, usernameCredentials.errorMessageId, Toast.LENGTH_LONG).show()
             !passwordCredentials.credentialIsValid ->
-                Toast.makeText(activityContext, passwordCredentials.errorMessage, Toast.LENGTH_LONG).show()
+                Toast.makeText(activityContext, passwordCredentials.errorMessageId, Toast.LENGTH_LONG).show()
+            !vncPasswordCredentials.credentialIsValid ->
+                Toast.makeText(activityContext, vncPasswordCredentials.errorMessageId, Toast.LENGTH_LONG).show()
             else ->
                 return true
         }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -180,7 +180,7 @@ class FilesystemEditFragment : Fragment() {
     }
 
     private fun filesystemParametersAreCorrect(): Boolean {
-        val validator = ValidationUtility()
+        val validator = ValidationUtility(activityContext.resources)
         val username = filesystem.defaultUsername
         val password = filesystem.defaultPassword
         val vncPassword = filesystem.defaultVncPassword
@@ -190,25 +190,16 @@ class FilesystemEditFragment : Fragment() {
             return false
         }
 
+        val usernameCredentials = validator.validateUsername(username)
+        val passwordCredentials = validator.validatePasswords(password, vncPassword)
+
         when {
-            username.isEmpty() || password.isEmpty() || vncPassword.isEmpty() -> {
-                Toast.makeText(activityContext, R.string.error_empty_field, Toast.LENGTH_LONG).show()
-            }
-            vncPassword.length > 8 || vncPassword.length < 6 -> {
-                Toast.makeText(activityContext, R.string.error_vnc_password_length_incorrect, Toast.LENGTH_LONG).show()
-            }
-            !validator.isUsernameValid(username) -> {
-                Toast.makeText(activityContext, R.string.error_username_invalid, Toast.LENGTH_LONG).show()
-            }
-            !validator.isPasswordValid(password) -> {
-                Toast.makeText(activityContext, R.string.error_password_invalid, Toast.LENGTH_LONG).show()
-            }
-            !validator.isPasswordValid(vncPassword) -> {
-                Toast.makeText(activityContext, R.string.error_vnc_password_invalid, Toast.LENGTH_LONG).show()
-            }
-            else -> {
+            !usernameCredentials.credentialIsValid ->
+                Toast.makeText(activityContext, usernameCredentials.errorMessage, Toast.LENGTH_LONG).show()
+            !passwordCredentials.credentialIsValid ->
+                Toast.makeText(activityContext, passwordCredentials.errorMessage, Toast.LENGTH_LONG).show()
+            else ->
                 return true
-            }
         }
         return false
     }

--- a/app/src/main/java/tech/ula/utils/ValidationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ValidationUtility.kt
@@ -1,59 +1,53 @@
 package tech.ula.utils
 
-import android.content.res.Resources
 import tech.ula.R
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-class ValidationUtility(systemResources: Resources) {
+class ValidationUtility(blacklisted_usernames: Array<String>) {
 
-    private val resources = systemResources
+    private val blacklist = blacklisted_usernames
 
     fun validateUsername(username: String): Credential {
-        var usernameIsValid = false
-        var errorMessage = ""
-        val blacklist = resources.getStringArray(R.array.blacklisted_usernames)
+        return when {
+            username.isEmpty() ->
+                Credential(false, R.string.error_empty_field)
 
-        when {
-            username.isEmpty() -> {
-                errorMessage = resources.getString(R.string.error_empty_field)
-            }
-            !validateUsernameCharacters(username) -> {
-                errorMessage = resources.getString(R.string.error_username_invalid_characters)
-            }
-            blacklist.contains(username) -> {
-                errorMessage = resources.getString(R.string.error_username_in_blacklist)
-                errorMessage = String.format(errorMessage, username)
-            }
-            else ->
-                usernameIsValid = true
+            !validateUsernameCharacters(username) ->
+                Credential(false, R.string.error_username_invalid_characters)
+
+            blacklist.contains(username) ->
+                Credential(false, R.string.error_username_in_blacklist)
+
+            else -> Credential(true)
         }
-
-        return Credential(usernameIsValid, errorMessage)
     }
 
-    fun validatePasswords(password: String, vncPassword: String): Credential {
-        var passwordIsValid = false
-        var errorMessage = ""
+    fun validatePassword(password: String): Credential {
+        return when {
+            password.isEmpty() ->
+                Credential(false, R.string.error_empty_field)
 
-        when {
-            password.isEmpty() || vncPassword.isEmpty() -> {
-                errorMessage = resources.getString(R.string.error_empty_field)
-            }
-            vncPassword.length > 8 || vncPassword.length < 6 -> {
-                errorMessage = resources.getString(R.string.error_vnc_password_length_incorrect)
-            }
-            !validatePasswordCharacters(password) -> {
-                errorMessage = resources.getString(R.string.error_password_invalid)
-            }
-            !validatePasswordCharacters(vncPassword) -> {
-                errorMessage = resources.getString(R.string.error_vnc_password_invalid)
-            }
-            else ->
-                passwordIsValid = true
+            !validatePasswordCharacters(password) ->
+                Credential(false, R.string.error_password_invalid)
+
+            else -> Credential(true)
         }
+    }
 
-        return Credential(passwordIsValid, errorMessage)
+    fun validateVncPassword(vncPassword: String): Credential {
+        return when {
+            vncPassword.isEmpty() ->
+                Credential(false, R.string.error_empty_field)
+
+            vncPassword.length > 8 || vncPassword.length < 6 ->
+                Credential(false, R.string.error_vnc_password_length_incorrect)
+
+            !validatePasswordCharacters(vncPassword) ->
+                Credential(false, R.string.error_vnc_password_invalid)
+
+            else -> Credential(true)
+        }
     }
 
     private fun validateUsernameCharacters(username: String): Boolean {
@@ -82,5 +76,4 @@ class ValidationUtility(systemResources: Resources) {
     }
 }
 
-sealed class CredentialValidation
-data class Credential(val credentialIsValid: Boolean, val errorMessage: String) : CredentialValidation()
+data class Credential(val credentialIsValid: Boolean, val errorMessageId: Int = 0)

--- a/app/src/main/java/tech/ula/utils/ValidationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ValidationUtility.kt
@@ -1,31 +1,86 @@
 package tech.ula.utils
 
+import android.content.res.Resources
+import tech.ula.R
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-class ValidationUtility() {
+class ValidationUtility(systemResources: Resources) {
 
-    fun isUsernameValid(password: String): Boolean {
-        val pattern: Pattern
-        val matcher: Matcher
+    private val resources = systemResources
 
-        val USERNAME_REGEX = "^[a-zA-Z0-9]*\$"
+    fun validateUsername(username: String): Credential {
+        var usernameIsValid = false
+        var errorMessage = ""
+        val blacklist = resources.getStringArray(R.array.blacklisted_usernames)
 
-        pattern = Pattern.compile(USERNAME_REGEX)
-        matcher = pattern.matcher(password)
+        when {
+            username.isEmpty() -> {
+                errorMessage = resources.getString(R.string.error_empty_field)
+            }
+            !validateUsernameCharacters(username) -> {
+                errorMessage = resources.getString(R.string.error_username_invalid_characters)
+            }
+            blacklist.contains(username) -> {
+                errorMessage = resources.getString(R.string.error_username_in_blacklist)
+                errorMessage = String.format(errorMessage, username)
+            }
+            else ->
+                usernameIsValid = true
+        }
 
-        return matcher.matches()
+        return Credential(usernameIsValid, errorMessage)
     }
 
-    fun isPasswordValid(password: String): Boolean {
+    fun validatePasswords(password: String, vncPassword: String): Credential {
+        var passwordIsValid = false
+        var errorMessage = ""
+
+        when {
+            password.isEmpty() || vncPassword.isEmpty() -> {
+                errorMessage = resources.getString(R.string.error_empty_field)
+            }
+            vncPassword.length > 8 || vncPassword.length < 6 -> {
+                errorMessage = resources.getString(R.string.error_vnc_password_length_incorrect)
+            }
+            !validatePasswordCharacters(password) -> {
+                errorMessage = resources.getString(R.string.error_password_invalid)
+            }
+            !validatePasswordCharacters(vncPassword) -> {
+                errorMessage = resources.getString(R.string.error_vnc_password_invalid)
+            }
+            else ->
+                passwordIsValid = true
+        }
+
+        return Credential(passwordIsValid, errorMessage)
+    }
+
+    private fun validateUsernameCharacters(username: String): Boolean {
+        val usernameRegex = "([a-z_][a-z0-9_]{0,30})"
+
+        val compiledRegex = Pattern.compile(usernameRegex)
+        val matcher = compiledRegex.matcher(username)
+        val hasValidCharacters = matcher.matches()
+
+        if (hasValidCharacters) {
+            return true
+        }
+        return false
+    }
+
+    private fun validatePasswordCharacters(password: String): Boolean {
         val pattern: Pattern
         val matcher: Matcher
 
-        val PASSWORD_REGEX = "^[a-zA-Z0-9!@#$%^&*()_+=,./?<>:]*\$"
+        val passwordRegex = "^[a-zA-Z0-9!@#$%^&*()_+=,./?<>:]*\$"
 
-        pattern = Pattern.compile(PASSWORD_REGEX)
+        pattern = Pattern.compile(passwordRegex)
         matcher = pattern.matcher(password)
 
         return matcher.matches()
     }
 }
+
+sealed class CredentialValidation
+data class Credential(val credentialIsValid: Boolean, val errorMessage: String) : CredentialValidation()

--- a/app/src/main/java/tech/ula/utils/ValidationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ValidationUtility.kt
@@ -4,49 +4,47 @@ import tech.ula.R
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-class ValidationUtility(blacklisted_usernames: Array<String>) {
+class ValidationUtility {
 
-    private val blacklist = blacklisted_usernames
-
-    fun validateUsername(username: String): Credential {
+    fun validateUsername(username: String, blacklistUsernames: Array<String>): CredentialValidationStatus {
         return when {
             username.isEmpty() ->
-                Credential(false, R.string.error_empty_field)
+                CredentialValidationStatus(false, R.string.error_empty_field)
 
             !validateUsernameCharacters(username) ->
-                Credential(false, R.string.error_username_invalid_characters)
+                CredentialValidationStatus(false, R.string.error_username_invalid_characters)
 
-            blacklist.contains(username) ->
-                Credential(false, R.string.error_username_in_blacklist)
+            blacklistUsernames.contains(username) ->
+                CredentialValidationStatus(false, R.string.error_username_in_blacklist)
 
-            else -> Credential(true)
+            else -> CredentialValidationStatus(true)
         }
     }
 
-    fun validatePassword(password: String): Credential {
+    fun validatePassword(password: String): CredentialValidationStatus {
         return when {
             password.isEmpty() ->
-                Credential(false, R.string.error_empty_field)
+                CredentialValidationStatus(false, R.string.error_empty_field)
 
             !validatePasswordCharacters(password) ->
-                Credential(false, R.string.error_password_invalid)
+                CredentialValidationStatus(false, R.string.error_password_invalid)
 
-            else -> Credential(true)
+            else -> CredentialValidationStatus(true)
         }
     }
 
-    fun validateVncPassword(vncPassword: String): Credential {
+    fun validateVncPassword(vncPassword: String): CredentialValidationStatus {
         return when {
             vncPassword.isEmpty() ->
-                Credential(false, R.string.error_empty_field)
+                CredentialValidationStatus(false, R.string.error_empty_field)
 
             vncPassword.length > 8 || vncPassword.length < 6 ->
-                Credential(false, R.string.error_vnc_password_length_incorrect)
+                CredentialValidationStatus(false, R.string.error_vnc_password_length_incorrect)
 
             !validatePasswordCharacters(vncPassword) ->
-                Credential(false, R.string.error_vnc_password_invalid)
+                CredentialValidationStatus(false, R.string.error_vnc_password_invalid)
 
-            else -> Credential(true)
+            else -> CredentialValidationStatus(true)
         }
     }
 
@@ -76,4 +74,4 @@ class ValidationUtility(blacklisted_usernames: Array<String>) {
     }
 }
 
-data class Credential(val credentialIsValid: Boolean, val errorMessageId: Int = 0)
+data class CredentialValidationStatus(val credentialIsValid: Boolean, val errorMessageId: Int = 0)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,5 +34,74 @@
         <item>VNC - TightVNC</item>
         <item>SDL - XSDL</item>
     </string-array>
-    
+
+    <string-array name="blacklisted_usernames">
+        <item>adm</item>
+        <item>audio</item>
+        <item>autologin</item>
+        <item>backup</item>
+        <item>bin</item>
+        <item>cdrom</item>
+        <item>daemon</item>
+        <item>dbus</item>
+        <item>dialout</item>
+        <item>dip</item>
+        <item>disk</item>
+        <item>fax</item>
+        <item>floppy</item>
+        <item>ftp</item>
+        <item>games</item>
+        <item>gnats</item>
+        <item>http</item>
+        <item>input</item>
+        <item>irc</item>
+        <item>kmem</item>
+        <item>kvm</item>
+        <item>list</item>
+        <item>locate</item>
+        <item>lock</item>
+        <item>log</item>
+        <item>lp</item>
+        <item>lpadmin</item>
+        <item>mail</item>
+        <item>mem</item>
+        <item>netdev</item>
+        <item>network</item>
+        <item>news</item>
+        <item>nobody</item>
+        <item>nogroup</item>
+        <item>operator</item>
+        <item>optical</item>
+        <item>plugdev</item>
+        <item>postgres</item>
+        <item>power</item>
+        <item>proc</item>
+        <item>proxy</item>
+        <item>rfkill</item>
+        <item>root</item>
+        <item>sambashare</item>
+        <item>sasl</item>
+        <item>scanner</item>
+        <item>shadow</item>
+        <item>smmsp</item>
+        <item>src</item>
+        <item>staff</item>
+        <item>storage</item>
+        <item>sudo</item>
+        <item>sync</item>
+        <item>sys</item>
+        <item>systemd-journal</item>
+        <item>tape</item>
+        <item>tty</item>
+        <item>users</item>
+        <item>utmp</item>
+        <item>uucp</item>
+        <item>uuidd</item>
+        <item>vboxusers</item>
+        <item>video</item>
+        <item>voice</item>
+        <item>wheel</item>
+        <item>www-data</item>
+
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="error_password_invalid">Password has invalid characters</string>
     <string name="error_vnc_password_invalid">VNC Password has invalid characters</string>
     <string name="error_username_invalid_characters">Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.</string>
-    <string name="error_username_in_blacklist">The username: `%1$s` is reserved and cannot be used as a filesystem username.</string>
+    <string name="error_username_in_blacklist">That username is possibly reserved by Linux and cannot be used as a filesystem username.</string>
 
     <!-- Illegal State Dialog -->
     <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="error_username_invalid">Username has invalid characters</string>
     <string name="error_password_invalid">Password has invalid characters</string>
     <string name="error_vnc_password_invalid">VNC Password has invalid characters</string>
+    <string name="error_username_invalid_characters">Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.</string>
+    <string name="error_username_in_blacklist">The username: `%1$s` is reserved and cannot be used as a filesystem username.</string>
 
     <!-- Illegal State Dialog -->
     <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -1,6 +1,5 @@
 package tech.ula.utils
 
-import android.content.res.Resources
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -18,22 +17,19 @@ class ValidationUtilityTest {
     lateinit var validationUtility: ValidationUtility
 
     @Mock
-    lateinit var credential: Credential
+    lateinit var credential: CredentialValidationStatus
 
-    @Mock
-    lateinit var resources: Resources
+    private var blacklistUsernames = arrayOf("root")
 
     @Before
     fun setup() {
-        val blacklistedUsernames = arrayOf("root")
-        validationUtility = ValidationUtility(blacklistedUsernames)
+        validationUtility = ValidationUtility()
     }
 
     @Test
     fun `Validate fails appropriately if username is empty`() {
         val username = ""
-
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_empty_field)
     }
@@ -41,7 +37,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation fails appropriately if username is capitalized`() {
         val username = "A"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
@@ -49,7 +45,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation fails appropriately if username has capital letters`() {
         val username = "abC"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
@@ -57,7 +53,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation fails appropriately if username starts with numbers`() {
         val username = "123abc"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
@@ -65,7 +61,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation succeeds appropriately if username starts with underscore`() {
         val username = "_123abc"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertTrue(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, 0)
     }
@@ -73,7 +69,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation fails appropriately if username has space`() {
         val username = "user name"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
@@ -81,7 +77,7 @@ class ValidationUtilityTest {
     @Test
     fun `Validation fails appropriately if username is too long`() {
         val username = "abcdefghijklmnopqrstuvwxyz123456"
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
@@ -90,7 +86,7 @@ class ValidationUtilityTest {
     fun `Validation fails appropriately if username is in blacklist`() {
         val username = "root"
 
-        credential = validationUtility.validateUsername(username)
+        credential = validationUtility.validateUsername(username, blacklistUsernames)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_username_in_blacklist)
     }

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -99,8 +99,6 @@ class ValidationUtilityTest {
                 "www-data"
         )
 
-        whenever(resources.getStringArray(R.array.blacklisted_usernames))
-                .thenReturn(arrayOf("adm", "audio"))
         whenever(resources.getString(R.string.error_empty_field))
                 .thenReturn("Each field must be entered!")
         whenever(resources.getString(R.string.error_username_invalid_characters))

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -104,7 +104,7 @@ class ValidationUtilityTest {
     fun `Validation fails appropriately if vnc password is empty`() {
         val vncPassword = ""
 
-        credential = validationUtility.validatePassword(vncPassword)
+        credential = validationUtility.validateVncPassword(vncPassword)
         assertFalse(credential.credentialIsValid)
         assertEquals(credential.errorMessageId, R.string.error_empty_field)
     }

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -155,6 +155,22 @@ class ValidationUtilityTest {
     }
 
     @Test
+    fun `Username has space`() {
+        val username = "user name"
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+    }
+
+    @Test
+    fun `Username is too long`() {
+        val username = "abcdefghijklmnopqrstuvwxyz123456"
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+    }
+
+    @Test
     fun `Username is in blacklist`() {
         val username = "root"
         whenever(resources.getString(R.string.error_username_in_blacklist))

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -1,0 +1,229 @@
+package tech.ula.utils
+
+import android.content.res.Resources
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import tech.ula.R
+
+@RunWith(MockitoJUnitRunner::class)
+class ValidationUtilityTest {
+
+    @Mock
+    lateinit var validationUtility: ValidationUtility
+
+    @Mock
+    lateinit var credential: Credential
+
+    @Mock
+    lateinit var resources: Resources
+
+    private val defaultPassword = "password"
+
+    @Before
+    fun setup() {
+        validationUtility = ValidationUtility(resources)
+
+        val blacklistedUsernames = arrayOf(
+                "adm",
+                "audio",
+                "autologin",
+                "backup",
+                "bin",
+                "cdrom",
+                "daemon",
+                "dbus",
+                "dialout",
+                "dip",
+                "disk",
+                "fax",
+                "floppy",
+                "ftp",
+                "games",
+                "gnats",
+                "http",
+                "input",
+                "irc",
+                "kmem",
+                "kvm",
+                "list",
+                "locate",
+                "lock",
+                "log",
+                "lp",
+                "lpadmin",
+                "mail",
+                "mem",
+                "netdev",
+                "network",
+                "news",
+                "nobody",
+                "nogroup",
+                "operator",
+                "optical",
+                "plugdev",
+                "postgres",
+                "power",
+                "proc",
+                "proxy",
+                "rfkill",
+                "root",
+                "sambashare",
+                "sasl",
+                "scanner",
+                "shadow",
+                "smmsp",
+                "src",
+                "staff",
+                "storage",
+                "sudo",
+                "sync",
+                "sys",
+                "systemd-journal",
+                "tape",
+                "tty",
+                "users",
+                "utmp",
+                "uucp",
+                "uuidd",
+                "vboxusers",
+                "video",
+                "voice",
+                "wheel",
+                "www-data"
+        )
+
+        whenever(resources.getStringArray(R.array.blacklisted_usernames))
+                .thenReturn(arrayOf("adm", "audio"))
+        whenever(resources.getString(R.string.error_empty_field))
+                .thenReturn("Each field must be entered!")
+        whenever(resources.getString(R.string.error_username_invalid_characters))
+                .thenReturn("Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        whenever(resources.getStringArray(R.array.blacklisted_usernames))
+                .thenReturn(blacklistedUsernames)
+        whenever(resources.getString(R.string.error_password_invalid))
+                .thenReturn("Password has invalid characters")
+        whenever(resources.getString(R.string.error_vnc_password_invalid))
+                .thenReturn("VNC Password has invalid characters")
+        whenever(resources.getString(R.string.error_vnc_password_length_incorrect))
+                .thenReturn("VNC Password must be between 6 to 8 characters!")
+    }
+
+    @Test
+    fun `Username is empty`() {
+        val username = ""
+
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Each field must be entered!")
+    }
+
+    @Test
+    fun `Username is capitalized`() {
+        val username = "A"
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+    }
+
+    @Test
+    fun `Username has capital letters`() {
+        val username = "abC"
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+    }
+
+    @Test
+    fun `Username starts with numbers`() {
+        val username = "123abc"
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+    }
+
+    @Test
+    fun `Username starts with underscore`() {
+        val username = "_123abc"
+        credential = validationUtility.validateUsername(username)
+        assertTrue(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "")
+    }
+
+    @Test
+    fun `Username is in blacklist`() {
+        val username = "root"
+        whenever(resources.getString(R.string.error_username_in_blacklist))
+                .thenReturn("The username: `root` is reserved and cannot be used as a filesystem username.")
+
+        credential = validationUtility.validateUsername(username)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "The username: `root` is reserved and cannot be used as a filesystem username.")
+    }
+
+    @Test
+    fun `password is empty`() {
+        val password = ""
+        val vncPassword = defaultPassword
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Each field must be entered!")
+    }
+
+    @Test
+    fun `vnc password is empty`() {
+        val password = defaultPassword
+        val vncPassword = ""
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Each field must be entered!")
+    }
+
+    @Test
+    fun `vnc password is too long`() {
+        val password = defaultPassword
+        val vncPassword = "abcdefghijklmnop"
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "VNC Password must be between 6 to 8 characters!")
+    }
+
+    @Test
+    fun `vnc password is too short`() {
+        val password = defaultPassword
+        val vncPassword = "abc"
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "VNC Password must be between 6 to 8 characters!")
+    }
+
+    @Test
+    fun `password has a space`() {
+        val password = "pass word"
+        val vncPassword = defaultPassword
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "Password has invalid characters")
+    }
+
+    @Test
+    fun `vnc password has a space`() {
+        val password = defaultPassword
+        val vncPassword = "te sting"
+
+        credential = validationUtility.validatePasswords(password, vncPassword)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessage, "VNC Password has invalid characters")
+    }
+}

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -1,7 +1,6 @@
 package tech.ula.utils
 
 import android.content.res.Resources
-import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -24,220 +24,129 @@ class ValidationUtilityTest {
     @Mock
     lateinit var resources: Resources
 
-    private val defaultPassword = "password"
-
     @Before
     fun setup() {
-        validationUtility = ValidationUtility(resources)
-
-        val blacklistedUsernames = arrayOf(
-                "adm",
-                "audio",
-                "autologin",
-                "backup",
-                "bin",
-                "cdrom",
-                "daemon",
-                "dbus",
-                "dialout",
-                "dip",
-                "disk",
-                "fax",
-                "floppy",
-                "ftp",
-                "games",
-                "gnats",
-                "http",
-                "input",
-                "irc",
-                "kmem",
-                "kvm",
-                "list",
-                "locate",
-                "lock",
-                "log",
-                "lp",
-                "lpadmin",
-                "mail",
-                "mem",
-                "netdev",
-                "network",
-                "news",
-                "nobody",
-                "nogroup",
-                "operator",
-                "optical",
-                "plugdev",
-                "postgres",
-                "power",
-                "proc",
-                "proxy",
-                "rfkill",
-                "root",
-                "sambashare",
-                "sasl",
-                "scanner",
-                "shadow",
-                "smmsp",
-                "src",
-                "staff",
-                "storage",
-                "sudo",
-                "sync",
-                "sys",
-                "systemd-journal",
-                "tape",
-                "tty",
-                "users",
-                "utmp",
-                "uucp",
-                "uuidd",
-                "vboxusers",
-                "video",
-                "voice",
-                "wheel",
-                "www-data"
-        )
-
-        whenever(resources.getString(R.string.error_empty_field))
-                .thenReturn("Each field must be entered!")
-        whenever(resources.getString(R.string.error_username_invalid_characters))
-                .thenReturn("Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
-        whenever(resources.getStringArray(R.array.blacklisted_usernames))
-                .thenReturn(blacklistedUsernames)
-        whenever(resources.getString(R.string.error_password_invalid))
-                .thenReturn("Password has invalid characters")
-        whenever(resources.getString(R.string.error_vnc_password_invalid))
-                .thenReturn("VNC Password has invalid characters")
-        whenever(resources.getString(R.string.error_vnc_password_length_incorrect))
-                .thenReturn("VNC Password must be between 6 to 8 characters!")
+        val blacklistedUsernames = arrayOf("root")
+        validationUtility = ValidationUtility(blacklistedUsernames)
     }
 
     @Test
-    fun `Username is empty`() {
+    fun `Validate fails appropriately if username is empty`() {
         val username = ""
 
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Each field must be entered!")
+        assertEquals(credential.errorMessageId, R.string.error_empty_field)
     }
 
     @Test
-    fun `Username is capitalized`() {
+    fun `Validation fails appropriately if username is capitalized`() {
         val username = "A"
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
 
     @Test
-    fun `Username has capital letters`() {
+    fun `Validation fails appropriately if username has capital letters`() {
         val username = "abC"
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
 
     @Test
-    fun `Username starts with numbers`() {
+    fun `Validation fails appropriately if username starts with numbers`() {
         val username = "123abc"
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
 
     @Test
-    fun `Username starts with underscore`() {
+    fun `Validation succeeds appropriately if username starts with underscore`() {
         val username = "_123abc"
         credential = validationUtility.validateUsername(username)
         assertTrue(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "")
+        assertEquals(credential.errorMessageId, 0)
     }
 
     @Test
-    fun `Username has space`() {
+    fun `Validation fails appropriately if username has space`() {
         val username = "user name"
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
 
     @Test
-    fun `Username is too long`() {
+    fun `Validation fails appropriately if username is too long`() {
         val username = "abcdefghijklmnopqrstuvwxyz123456"
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.")
+        assertEquals(credential.errorMessageId, R.string.error_username_invalid_characters)
     }
 
     @Test
-    fun `Username is in blacklist`() {
+    fun `Validation fails appropriately if username is in blacklist`() {
         val username = "root"
-        whenever(resources.getString(R.string.error_username_in_blacklist))
-                .thenReturn("The username: `root` is reserved and cannot be used as a filesystem username.")
 
         credential = validationUtility.validateUsername(username)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "The username: `root` is reserved and cannot be used as a filesystem username.")
+        assertEquals(credential.errorMessageId, R.string.error_username_in_blacklist)
     }
 
     @Test
-    fun `password is empty`() {
+    fun `Validation fails appropriately if password is empty`() {
         val password = ""
-        val vncPassword = defaultPassword
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validatePassword(password)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Each field must be entered!")
+        assertEquals(credential.errorMessageId, R.string.error_empty_field)
     }
 
     @Test
-    fun `vnc password is empty`() {
-        val password = defaultPassword
+    fun `Validation fails appropriately if vnc password is empty`() {
         val vncPassword = ""
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validatePassword(vncPassword)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Each field must be entered!")
+        assertEquals(credential.errorMessageId, R.string.error_empty_field)
     }
 
     @Test
-    fun `vnc password is too long`() {
-        val password = defaultPassword
+    fun `Validation fails appropriately if vnc password is too long`() {
         val vncPassword = "abcdefghijklmnop"
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validateVncPassword(vncPassword)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "VNC Password must be between 6 to 8 characters!")
+        assertEquals(credential.errorMessageId, R.string.error_vnc_password_length_incorrect)
     }
 
     @Test
-    fun `vnc password is too short`() {
-        val password = defaultPassword
+    fun `Validation fails appropriately if vnc password is too short`() {
         val vncPassword = "abc"
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validateVncPassword(vncPassword)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "VNC Password must be between 6 to 8 characters!")
+        assertEquals(credential.errorMessageId, R.string.error_vnc_password_length_incorrect)
     }
 
     @Test
-    fun `password has a space`() {
+    fun `Validation fails appropriately if password has a space`() {
         val password = "pass word"
-        val vncPassword = defaultPassword
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validatePassword(password)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "Password has invalid characters")
+        assertEquals(credential.errorMessageId, R.string.error_password_invalid)
     }
 
     @Test
-    fun `vnc password has a space`() {
-        val password = defaultPassword
+    fun `Validation fails appropriately if vnc password has a space`() {
         val vncPassword = "te sting"
 
-        credential = validationUtility.validatePasswords(password, vncPassword)
+        credential = validationUtility.validateVncPassword(vncPassword)
         assertFalse(credential.credentialIsValid)
-        assertEquals(credential.errorMessage, "VNC Password has invalid characters")
+        assertEquals(credential.errorMessageId, R.string.error_vnc_password_invalid)
     }
 }


### PR DESCRIPTION
**Describe the pull request**

Moved username and password validation logic from `MainActivity` into the `ValidationUtility` class.  Now it will return a `Credential` object that has two properties: a boolean of whether the string is valid and an error message to display in a Toast dialog about why the string is invalid.

Also added a blacklist of usernames that the user cannot choose from because they are used in Linux distros as group names.

There are now some tests too 👍 

**Link to relevant issues**
#460
#577 
