### PR TITLE
Handle syncing download state onResume.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -191,6 +191,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     override fun onResume() {
         super.onResume()
 
+        acraWrapper.putCustomString("Last call to onResume", "${System.currentTimeMillis()}")
+        viewModel.handleOnResume()
         val intent = Intent(this, ServerService::class.java)
                 .putExtra("type", "isProgressBarActive")
         this.startService(intent)
@@ -211,6 +213,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
     override fun onStop() {
         super.onStop()
+
+        acraWrapper.putCustomString("Last call to onStop", "${System.currentTimeMillis()}")
         LocalBroadcastManager.getInstance(this)
                 .unregisterReceiver(serverServiceBroadcastReceiver)
         unregisterReceiver(downloadBroadcastReceiver)
@@ -384,6 +388,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             }
             is DownloadCacheAccessedWhileEmpty -> {
                 getString(R.string.illegal_state_empty_download_cache_access)
+            }
+            is DownloadCacheAccessedInAnIncorrectState -> {
+                getString(R.string.illegal_state_download_cache_access_in_incorrect_state)
             }
             is FailedToCopyAssetsToFilesystem -> {
                 getString(R.string.illegal_state_failed_to_copy_assets_to_filesystem)

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -85,6 +85,10 @@ class MainActivityViewModel(
         return state
     }
 
+    fun handleOnResume() {
+        submitSessionStartupEvent(SyncDownloadState)
+    }
+
     fun waitForPermissions(appToContinue: App = unselectedApp, sessionToContinue: Session = unselectedSession) {
         resetStartupState()
         lastSelectedApp = appToContinue
@@ -302,7 +306,9 @@ class MainActivityViewModel(
             is DownloadsHaveFailed -> state.postValue(DownloadsDidNotCompleteSuccessfully(newState.reason))
             is AttemptedCacheAccessWhileEmpty -> {
                 state.postValue(DownloadCacheAccessedWhileEmpty)
-                resetStartupState()
+            }
+            is AttemptedCacheAccessInIncorrectState -> {
+                state.postValue(DownloadCacheAccessedInAnIncorrectState)
             }
         }
     }
@@ -396,6 +402,7 @@ object NoSessionSelectedWhenTransitionNecessary : IllegalState()
 object ErrorFetchingAssetLists : IllegalState()
 data class DownloadsDidNotCompleteSuccessfully(val reason: String) : IllegalState()
 object DownloadCacheAccessedWhileEmpty : IllegalState()
+object DownloadCacheAccessedInAnIncorrectState : IllegalState()
 object FailedToCopyAssetsToLocalStorage : IllegalState()
 object AssetsHaveNotBeenDownloaded : IllegalState()
 object FailedToCopyAssetsToFilesystem : IllegalState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="illegal_state_failed_to_copy_assets_to_local">Failed to copy assets to local storage. Try clearing support files.</string>
     <string name="illegal_state_assets_have_not_been_downloaded">Assets need to be copied to your filesystem, but it looks like they have not been downloaded. Try clearing support files.</string>
     <string name="illegal_state_empty_download_cache_access">The downloads cache was empty when access was attempted.</string>
+    <string name="illegal_state_download_cache_access_in_incorrect_state">The downloads cache was accessed while in a state which does not support that.</string>
     <string name="illegal_state_failed_to_copy_assets_to_filesystem">Failed to copy assets to filesystem. Try clearing support files.</string>
     <string name="illegal_state_failed_to_extract_filesystem">Failed to extract filesystem. Try clearing support files.</string>
     <string name="illegal_state_failed_to_clear_support_files">Failed to clear support files.</string>

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -84,6 +84,13 @@ class MainActivityViewModelTest {
     }
 
     @Test
+    fun `Handling onResume submits SyncDownloadState session event`() {
+        mainActivityViewModel.handleOnResume()
+
+        verify(mockSessionStartupFsm).submitEvent(SyncDownloadState, mainActivityViewModel)
+    }
+
+    @Test
     fun `Restarts app setup after permissions are granted if an app was selected first`() {
         mainActivityViewModel.waitForPermissions(appToContinue = selectedApp)
         mainActivityViewModel.permissionsHaveBeenGranted()
@@ -567,11 +574,13 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AttemptedCacheAccessWhileEmpty)
 
         verify(mockStateObserver).onChanged(DownloadCacheAccessedWhileEmpty)
-        verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
-        verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
-        assertEquals(unselectedApp, mainActivityViewModel.lastSelectedApp)
-        assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
-        assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
+    }
+
+    @Test
+    fun `Posts DownloadCacheAccessedInAnIncorrectState if AttemptedCacheAccessInIncorrectState is observed`() {
+        sessionStartupStateLiveData.postValue(AttemptedCacheAccessInIncorrectState)
+
+        verify(mockStateObserver).onChanged(DownloadCacheAccessedInAnIncorrectState)
     }
 
     @Test


### PR DESCRIPTION
**Describe the pull request**

We previously were only syncing the download state when the session fsm was being initialized. This solved the issue of process death, but did not solve the issue of the app being put into the background but not being killed. Now, the download state will be synced whenever the lifecycle method `onResume` is called on the main activity.

**Link to relevant issues**
N/A