### PR TITLE
Correctly copy downloads after syncing cached download state. Add som…

### DIFF
--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -85,6 +85,16 @@ class DownloadUtility(
         return enqueuedDownloadIds.contains(id)
     }
 
+    fun findDownloadedDistributionType(): String {
+        downloadDirectory.listFiles()?.forEach { downloadedFile ->
+            if (downloadedFile.name.containsUserland() && !downloadedFile.name.contains("support")) {
+                val (_, distributionType, _) = downloadedFile.name.split("-", limit = 3)
+                return distributionType
+            }
+        }
+        return ""
+    }
+
     private fun download(asset: Asset): Long {
         val branch = getBranchToDownloadAssetsFrom(asset.distributionType)
         val url = "https://github.com/CypherpunkArmory/UserLAnd-Assets-" +

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -295,14 +295,7 @@ class MainActivityViewModel(
     private fun handleDownloadingAssetsState(newState: DownloadingAssetsState) {
         return when (newState) {
             is DownloadingAssets -> state.postValue(DownloadProgress(newState.numCompleted, newState.numTotal))
-            is DownloadsHaveSucceeded -> {
-                if (sessionPreparationRequirementsHaveBeenSelected()) {
-                    submitSessionStartupEvent(CopyDownloadsToLocalStorage(lastSelectedFilesystem))
-                } else {
-                    state.postValue(ProgressBarOperationComplete)
-                    resetStartupState()
-                }
-            }
+            is DownloadsHaveSucceeded -> submitSessionStartupEvent(CopyDownloadsToLocalStorage)
             is DownloadsHaveFailed -> state.postValue(DownloadsDidNotCompleteSuccessfully(newState.reason))
             is AttemptedCacheAccessWhileEmpty -> {
                 state.postValue(DownloadCacheAccessedWhileEmpty)
@@ -316,9 +309,14 @@ class MainActivityViewModel(
     private fun handleCopyingFilesLocallyState(newState: CopyingFilesLocallyState) {
         return when (newState) {
             is CopyingFilesToLocalDirectories -> state.postValue(CopyingDownloads)
-            is LocalDirectoryCopySucceeded -> { doTransitionIfRequirementsAreSelected {
-                submitSessionStartupEvent(VerifyFilesystemAssets(lastSelectedFilesystem))
-            } }
+            is LocalDirectoryCopySucceeded -> {
+                if (sessionPreparationRequirementsHaveBeenSelected()) {
+                    submitSessionStartupEvent(VerifyFilesystemAssets(lastSelectedFilesystem))
+                } else {
+                    state.postValue(ProgressBarOperationComplete)
+                    resetStartupState()
+                }
+            }
             is LocalDirectoryCopyFailed -> state.postValue(FailedToCopyAssetsToLocalStorage)
         }
     }

--- a/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
@@ -299,4 +299,20 @@ class DownloadUtilityTest {
         val permissions2 = output.substring(0, 10)
         assertTrue(permissions2 == "-rwxrwxrwx")
     }
+
+    @Test
+    fun `Can parse a distribution type out of downloaded files`() {
+        val assetDownloadFile = File("${downloadDirectory.path}/${asset1.concatenatedName}")
+        assetDownloadFile.createNewFile()
+
+        val result = downloadUtility.findDownloadedDistributionType()
+
+        val expected = "distType1"
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `Returns empty string if no distributions are found in downloads directory`() {
+        assertEquals("", downloadUtility.findDownloadedDistributionType())
+    }
 }

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -455,6 +455,13 @@ class MainActivityViewModelTest {
     }
 
     @Test
+    fun `Posts NoSessionsSelectedWhenTransitionNecessary if incorrectly transitioning out of SessionIsReadyForPreparation observation`() {
+        sessionStartupStateLiveData.postValue(SessionIsReadyForPreparation(unselectedSession, unselectedFilesystem))
+
+        verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
+    }
+
+    @Test
     fun `Updates selected session and filesystem, posts StartingSetup, and submits RetrieveAssetLists when session is ready for prep is observed`() {
         sessionStartupStateLiveData.postValue(SessionIsReadyForPreparation(selectedSession, selectedFilesystem))
 
@@ -474,6 +481,14 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(RetrievingAssetLists)
 
         verify(mockStateObserver).onChanged(FetchingAssetLists)
+    }
+
+    @Test
+    fun `Posts NoSessionsSelectedWhenTransitionNecessary if AssetRetrievalSucceeded state is observed while no selections have been made`() {
+        val assetLists = listOf(listOf(asset))
+        sessionStartupStateLiveData.postValue(AssetListsRetrievalSucceeded(assetLists))
+
+        verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -529,6 +544,13 @@ class MainActivityViewModelTest {
     }
 
     @Test
+    fun `Posts NoSessionSelectedWhenTransitionNecessary if attempted to transition from NoDownloadsRequired while selections have not been made`() {
+        sessionStartupStateLiveData.postValue(NoDownloadsRequired)
+
+        verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
+    }
+
+    @Test
     fun `Submits VerifyFilesystemAssets event when observing NoDownloadsRequired`() {
         makeSessionSelections()
 
@@ -550,12 +572,10 @@ class MainActivityViewModelTest {
 
     @Test
     fun `Submits CopyDownloadsToLocalStorage event when observing download success`() {
-        makeSessionSelections()
-
         sessionStartupStateLiveData.postValue(DownloadsHaveSucceeded)
 
         runBlocking {
-            verify(mockSessionStartupFsm).submitEvent(CopyDownloadsToLocalStorage(selectedFilesystem), mainActivityViewModel)
+            verify(mockSessionStartupFsm).submitEvent(CopyDownloadsToLocalStorage, mainActivityViewModel)
         }
     }
 
@@ -585,15 +605,13 @@ class MainActivityViewModelTest {
 
     @Test
     fun `Posts CopyingDownloads when equivalent state is observed`() {
-        makeSessionSelections()
-
         sessionStartupStateLiveData.postValue(CopyingFilesToLocalDirectories)
 
         verify(mockStateObserver).onChanged(CopyingDownloads)
     }
 
     @Test
-    fun `Submits VerifyFilesystemAssets event when copying success is observed`() {
+    fun `Submits VerifyFilesystemAssets event when copying success is observed and session selections have been made`() {
         makeSessionSelections()
 
         sessionStartupStateLiveData.postValue(LocalDirectoryCopySucceeded)
@@ -604,9 +622,21 @@ class MainActivityViewModelTest {
     }
 
     @Test
-    fun `Posts IllegalState when copying failure is observed`() {
-        makeSessionSelections()
+    fun `Posts ProgressBarOperationComplete and resets session state when LocalDirectoryCopySucceeded observed while selections have not been made`() {
+        sessionStartupStateLiveData.postValue(LocalDirectoryCopySucceeded)
 
+        verify(mockStateObserver).onChanged(ProgressBarOperationComplete)
+        assertEquals(unselectedApp, mainActivityViewModel.lastSelectedApp)
+        assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
+        assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
+        runBlocking {
+            verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
+            verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
+        }
+    }
+
+    @Test
+    fun `Posts IllegalState when copying failure is observed`() {
         sessionStartupStateLiveData.postValue(LocalDirectoryCopyFailed)
 
         verify(mockStateObserver).onChanged(FailedToCopyAssetsToLocalStorage)
@@ -619,6 +649,13 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(VerifyingFilesystemAssets)
 
         verify(mockStateObserver).onChanged(VerifyingFilesystem)
+    }
+
+    @Test
+    fun `Posts NoSessionSelectedWhenTransitionNecessary if transitioning from FilesystemAssetVerificationSucceeded while selections have not been made`() {
+        sessionStartupStateLiveData.postValue(FilesystemAssetVerificationSucceeded)
+
+        verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -658,6 +695,13 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(ExtractingFilesystem(target))
 
         verify(mockStateObserver).onChanged(FilesystemExtractionStep(target))
+    }
+
+    @Test
+    fun `Posts NoSessionSelectedWhenTransitionNecessary when transitioning from ExtractionHasCompletedSuccessfully if no selections have been made`() {
+        sessionStartupStateLiveData.postValue(ExtractionHasCompletedSuccessfully)
+
+        verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test


### PR DESCRIPTION
**Describe the pull request**

Previously, we would only submit `CopyDownloadsToLocalStorage` events if a session/filesystem had been selected, meaning we were still actively in the session startup flow and not catching up with the cache.

This PR adds a method to the `DownloadUtility` that allows us to parse distribution types from assets so we can still set up when they were last updated, removing the reliance on having selected a filesystem. We can then accomplish the `CopyDownloadsToLocalStorage` event without the selections, and instead ensure the selections have been made in the next step, `VerifyFilesystemAssets` where it is actually necessary. We just kill the progress bar and reset the state there if the selections haven't been made.

Also added some missing tests for when we should error on illegal transitions.

**Link to relevant issues**
N/A