### PR TITLE
Use the correct type to derive download failure reason.

### DIFF
--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -345,12 +345,10 @@ class DownloadManagerWrapper(private val downloadManager: DownloadManager) {
         val query = generateQuery(id)
         val cursor = generateCursor(query)
         if (cursor.moveToFirst()) {
-            val status: String = cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_REASON))
-            if (status != "reason") {
-                return status
-            }
+            val status: Int = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON))
+            return "Reason: $status"
         }
-        return "No reason for failure"
+        return "No known reason for failure."
     }
 
     fun getDownloadsDirectory(): File {


### PR DESCRIPTION
**Describe the pull request**

Apparently, getting the status as a string always just returns: reason=placeholder, and we instead need to fetch an int (HTTP status code) from the cursor instead.

**Link to relevant issues**
