### PR TITLE
Fix crash related to attempting to acquire a wakelock

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,7 +172,7 @@ task jacocoCoverageReportForCi(type: JacocoReport, dependsOn: ['testDebugUnitTes
 }
 
 dependencies {
-    def acra_version = '5.1.3'
+    def acra_version = '5.2.1'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':terminal-term')

--- a/termux-app/terminal-term/src/main/AndroidManifest.xml
+++ b/termux-app/terminal-term/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application

--- a/termux-app/terminal-term/src/main/AndroidManifest.xml
+++ b/termux-app/terminal-term/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application


### PR DESCRIPTION
**Describe the pull request**

This PR addresses the issue when a user wants to acquire a wakelock through the UserLAnd terminal notification bar.  The error message that was displayed upon crash was that the app did not have permissions for using wakelock.  

The solution to this problem can be found in this [StackOverflow post](https://stackoverflow.com/questions/50972669/cannot-get-wake-lock-permission-on-android-8-oreo/50972790#50972790).

Including this PR change will enable wakelock permissions for the terminal again and prevent the crash from occurring.  

![debugging is difficult](https://media.giphy.com/media/m7W2h4TlK6kQQWHhLG/giphy.gif)


**Link to relevant issues**
 #614