### PR TITLE
Update extract command. Don't download rootfs if restoring from backup.

### DIFF
--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -149,8 +149,10 @@ class SessionStartupFsm(
             assetList.filter { asset ->
                 val needsUpdate = assetRepository.doesAssetNeedToUpdated(asset)
 
-                if (asset.isLarge && needsUpdate && filesystemUtility
-                                .hasFilesystemBeenSuccessfullyExtracted("${filesystem.id}")) {
+                // Rootfs tar files can be left of the download generation if the filesystem is
+                // being created from backup or has already been extracted.
+                if (asset.isLarge && needsUpdate && (filesystem.isCreatedFromBackup ||
+                        filesystemUtility.hasFilesystemBeenSuccessfullyExtracted("${filesystem.id}"))) {
                     return@filter false
                 }
                 needsUpdate

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -63,7 +63,7 @@ fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int) 
 // Add or change asset types as needed for testing and staggered releases.
 fun getBranchToDownloadAssetsFrom(assetType: String): String {
     return when (assetType) {
-        "support" -> "staging"
+        "support" -> "backup-restore"
         "apps" -> "master"
         else -> "master"
     }

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -40,7 +40,7 @@ class FilesystemUtility(
 
     fun extractFilesystem(filesystem: Filesystem, listener: (String) -> Any) {
         val filesystemDirName = "${filesystem.id}"
-        val command = "/support/extractFilesystem.sh"
+        val command = "/support/common/extractFilesystem.sh"
         val env = HashMap<String, String>()
         env["INITIAL_USERNAME"] = filesystem.defaultUsername
         env["INITIAL_PASSWORD"] = filesystem.defaultPassword

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -40,7 +40,7 @@ class FilesystemUtilityTest {
 
     @Test
     fun `Calling extract filesystem uses the appropriate command`() {
-        val command = "/support/extractFilesystem.sh"
+        val command = "/support/common/extractFilesystem.sh"
 
         val requiredFilesystemType = "testDist"
         val fakeArchitecture = "testArch"
@@ -49,7 +49,7 @@ class FilesystemUtilityTest {
                 defaultUsername = "username", defaultPassword = "password", defaultVncPassword = "vncpass")
         val filesystemDirName = "${filesystem.id}"
 
-        val defaultEnvironmentalVariables = hashMapOf<String, String>("INITIAL_USERNAME" to "username",
+        val defaultEnvironmentalVariables = hashMapOf("INITIAL_USERNAME" to "username",
                 "INITIAL_PASSWORD" to "password", "INITIAL_VNC_PASSWORD" to "vncpass")
         whenever(mockBusyboxExecutor.executeProotCommand(
                 eq(command),


### PR DESCRIPTION
**Describe the pull request**

This PR:
- updates command for extraction to use new `/support/common` binding.
- downloads assets from backup-restore support repo branch.
- ignores rootfs files when generating downloads if filesystem is being created from backup

**Link to relevant issues**
N/A