### PR TITLE
Add UI for filesystem backups import and export

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -608,11 +608,12 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         }
     }
 
-    override val getProgressBarAsListener: (String) -> Unit = { line ->
-        updateProgressBar(getString(R.string.progress_exporting_filesystem), line)
+    override fun updateExportProgress(details: String) {
+        val step = getString(R.string.progress_exporting_filesystem)
+        updateProgressBar(step, details)
     }
 
-    override fun stopProgressBar() {
+    override fun stopExportProgress() {
         killProgressBar()
     }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -608,7 +608,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         }
     }
 
-    override val getProgressBarAsListener:(String) -> Unit = { line ->
+    override val getProgressBarAsListener: (String) -> Unit = { line ->
         updateProgressBar(getString(R.string.progress_exporting_filesystem), line)
     }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -19,6 +19,7 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.provider.OpenableColumns
 import android.support.design.widget.TextInputEditText
 import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
@@ -61,9 +62,16 @@ import org.acra.config.CoreConfigurationBuilder
 import org.acra.config.HttpSenderConfigurationBuilder
 import org.acra.data.StringFormat
 import org.acra.sender.HttpSender
+import tech.ula.model.entities.Filesystem
+import tech.ula.ui.FilesystemEditFragment
+import java.io.File
+import java.io.FileOutputStream
 import kotlin.IllegalStateException
 
-class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection {
+class MainActivity : AppCompatActivity(),
+        SessionListFragment.SessionSelection,
+        AppListFragment.AppSelection,
+        FilesystemEditFragment.FilesystemImport {
 
     private val permissionRequestCode: Int by lazy {
         getString(R.string.permission_request_code).toInt()
@@ -296,6 +304,53 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             return
         }
         viewModel.submitSessionSelection(session)
+    }
+
+    override fun filesystemImportSelected(backupFilesystemUri: Uri, currentFilesystem: Filesystem): String {
+        var backupFilename = ""
+        if (!arePermissionsGranted(this)) {
+            showPermissionsNecessaryDialog()
+            viewModel.waitForPermissions()
+            return ""
+        }
+
+        contentResolver.query(backupFilesystemUri, null, null, null, null).use {
+            it?.let { cursor ->
+                if (cursor.moveToFirst()) {
+                    backupFilename = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+                    File("${filesDir.absolutePath}/backups").mkdirs()
+                    val destinationPath = "${filesDir.absolutePath}/backups/$backupFilename"
+                    val destination = File(destinationPath)
+                    if (!destination.exists()) {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            copyBackup(source = backupFilesystemUri, destination = destination)
+                        }
+                    }
+                }
+            }
+        }
+        return backupFilename
+    }
+
+    private fun copyBackup(source: Uri, destination: File) {
+        contentResolver.openInputStream(source)?.let { fileStream ->
+            val streamOutput = FileOutputStream(destination)
+            try {
+                val buffer = ByteArray(1024)
+                var len = 0
+                fileStream.use {
+                    while (len != -1) {
+                        len = fileStream.read(buffer)
+                        streamOutput.write(buffer, 0, len)
+                    }
+                }
+            } catch (e: Exception) {
+                val error = e
+            } finally {
+                fileStream.close()
+                streamOutput.close()
+            }
+        }
     }
 
     private fun handleStateUpdate(newState: State) {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -61,9 +61,10 @@ import org.acra.config.CoreConfigurationBuilder
 import org.acra.config.HttpSenderConfigurationBuilder
 import org.acra.data.StringFormat
 import org.acra.sender.HttpSender
+import tech.ula.ui.FilesystemListFragment
 import kotlin.IllegalStateException
 
-class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection {
+class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection, FilesystemListFragment.ExportFilesystem {
 
     private val permissionRequestCode: Int by lazy {
         getString(R.string.permission_request_code).toInt()
@@ -605,6 +606,14 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 killProgressBar()
             }
         }
+    }
+
+    override val getProgressBarAsListener:(String) -> Unit = { line ->
+        updateProgressBar(getString(R.string.progress_exporting_filesystem), line)
+    }
+
+    override fun stopProgressBar() {
+        killProgressBar()
     }
 
     private fun updateProgressBar(step: String, details: String) {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -61,14 +61,9 @@ import org.acra.config.CoreConfigurationBuilder
 import org.acra.config.HttpSenderConfigurationBuilder
 import org.acra.data.StringFormat
 import org.acra.sender.HttpSender
-import tech.ula.model.entities.Filesystem
-import tech.ula.ui.FilesystemListFragment
 import kotlin.IllegalStateException
 
-class MainActivity : AppCompatActivity(),
-        SessionListFragment.SessionSelection,
-        AppListFragment.AppSelection,
-        FilesystemListFragment.FilesystemExport {
+class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection {
 
     private val permissionRequestCode: Int by lazy {
         getString(R.string.permission_request_code).toInt()
@@ -301,14 +296,6 @@ class MainActivity : AppCompatActivity(),
             return
         }
         viewModel.submitSessionSelection(session)
-    }
-
-    override fun filesystemExportSelected(filesystem: Filesystem) {
-        if (!arePermissionsGranted(this)) {
-            showPermissionsNecessaryDialog()
-            viewModel.waitForPermissions()
-            return
-        }
     }
 
     private fun handleStateUpdate(newState: State) {

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -2,8 +2,11 @@ package tech.ula.ui
 
 import android.app.Activity
 import android.arch.lifecycle.ViewModelProviders
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.text.Editable
 import android.text.TextWatcher
@@ -89,6 +92,7 @@ class FilesystemEditFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupTextInputs()
+        setupImportButton()
 
         if (editExisting) {
             spinner_filesystem_type.isEnabled = false
@@ -153,6 +157,31 @@ class FilesystemEditFragment : Fragment() {
         })
     }
 
+    private fun setupImportButton() {
+        import_button.setOnClickListener {
+            val filePickerIntent = Intent(Intent.ACTION_GET_CONTENT)
+            filePickerIntent.type = "application/*"
+            filePickerIntent.addCategory(Intent.CATEGORY_OPENABLE)
+            val fileChooser = Intent.createChooser(filePickerIntent, "Select File")
+
+            try {
+                startActivityForResult(fileChooser, IMPORT_FILESYSTEM_REQUEST_CODE)
+            } catch (activityNotFoundErr: ActivityNotFoundException) {
+                Toast.makeText(activityContext, "Please install a File Manager.", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == IMPORT_FILESYSTEM_REQUEST_CODE) {
+            data?.data?.let {
+                val path = it.path
+                Toast.makeText(activityContext, "Location is: $path", Snackbar.LENGTH_LONG).show()
+            }
+        }
+    }
+
     private fun insertFilesystem(): Boolean {
         val navController = NavHostFragment.findNavController(this)
         if (!filesystemParametersAreCorrect()) {
@@ -203,5 +232,9 @@ class FilesystemEditFragment : Fragment() {
                 return true
         }
         return false
+    }
+
+    companion object {
+        val IMPORT_FILESYSTEM_REQUEST_CODE = 5
     }
 }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -242,7 +242,7 @@ class FilesystemEditFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, returnIntent)
         if (requestCode == IMPORT_FILESYSTEM_REQUEST_CODE) {
             returnIntent?.data?.let { uri ->
-                filesystemEditViewModel.setBackupUri(uri)
+                filesystemEditViewModel.backupUri = uri
                 text_backup_filename.text = uri.lastPathSegment
             }
         }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -8,7 +8,6 @@ import android.arch.lifecycle.ViewModelProviders
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.support.v4.app.Fragment

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -58,9 +58,10 @@ class FilesystemEditFragment : Fragment() {
 
     private val filesystemImportStatusObserver = Observer<FilesystemImportStatus> {
         it?.let { importStatus ->
+            val dialogBuilder = AlertDialog.Builder(activityContext)
             when (importStatus) {
-                is ImportSuccess -> Toast.makeText(activityContext, R.string.import_success, Toast.LENGTH_LONG).show()
-                is ImportFailure -> Toast.makeText(activityContext, R.string.import_failure, Toast.LENGTH_LONG).show()
+                is ImportSuccess -> dialogBuilder.setMessage(R.string.import_success).create().show()
+                is ImportFailure -> dialogBuilder.setMessage(R.string.import_failure).create().show()
             }
         }
     }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -5,7 +5,10 @@ import android.arch.lifecycle.ViewModelProviders
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.os.Environment
+import android.provider.OpenableColumns
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
 import android.text.Editable
@@ -29,6 +32,7 @@ import tech.ula.utils.BuildWrapper
 import tech.ula.utils.ValidationUtility
 import tech.ula.viewmodel.FilesystemEditViewModel
 import tech.ula.viewmodel.FilesystemEditViewmodelFactory
+import java.io.File
 
 class FilesystemEditFragment : Fragment() {
 
@@ -160,8 +164,13 @@ class FilesystemEditFragment : Fragment() {
     private fun setupImportButton() {
         import_button.setOnClickListener {
             val filePickerIntent = Intent(Intent.ACTION_GET_CONTENT)
-            filePickerIntent.type = "application/*"
-            filePickerIntent.addCategory(Intent.CATEGORY_OPENABLE)
+//            filePickerIntent.type = "application/*"
+//            filePickerIntent.addCategory(Intent.EXTRA_LOCAL_ONLY)
+            val userlandExternalStorageUri = Uri.parse("${Environment.getExternalStorageDirectory()}/UserLAnd")
+            val result = File("${Environment.getExternalStorageDirectory()}/UserLAnd").mkdirs()
+//            val filePickerIntent = Intent(Intent.ACTION_VIEW)
+//            filePickerIntent.addCategory(Intent.CATEGORY_OPENABLE)
+            filePickerIntent.setDataAndType(userlandExternalStorageUri, "*/*")
             val fileChooser = Intent.createChooser(filePickerIntent, "Select File")
 
             try {
@@ -176,6 +185,12 @@ class FilesystemEditFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == IMPORT_FILESYSTEM_REQUEST_CODE) {
             data?.data?.let {
+                var cursor = activityContext.contentResolver.query(it, null, null, null, null)
+//                val columIndex = cursor.getColumnIndexOrThrow("_data")
+                if (cursor.moveToFirst()) {
+                    val pathName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+                    val cheese = ""
+                }
                 val path = it.path
                 Toast.makeText(activityContext, "Location is: $path", Snackbar.LENGTH_LONG).show()
             }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -264,7 +264,8 @@ class FilesystemEditFragment : Fragment() {
                 return true
             }
             if (filesystem.isCreatedFromBackup) {
-                filesystemEditViewModel.insertFilesystemFromBackup(activityContext.contentResolver, filesystem, activityContext.filesDir)
+                val backupUri = filesystemEditViewModel.getBackupUri()
+                filesystemEditViewModel.insertFilesystemFromBackup(activityContext.contentResolver, filesystem, activityContext.filesDir, backupUri)
             } else {
                 filesystemEditViewModel.insertFilesystem(filesystem)
             }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -263,8 +263,7 @@ class FilesystemEditFragment : Fragment() {
                 return true
             }
             if (filesystem.isCreatedFromBackup) {
-                val backupUri = filesystemEditViewModel.getBackupUri()
-                filesystemEditViewModel.insertFilesystemFromBackup(activityContext.contentResolver, filesystem, activityContext.filesDir, backupUri)
+                filesystemEditViewModel.insertFilesystemFromBackup(activityContext.contentResolver, filesystem, activityContext.filesDir)
             } else {
                 filesystemEditViewModel.insertFilesystem(filesystem)
             }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -8,6 +8,7 @@ import android.arch.lifecycle.ViewModelProviders
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.support.v4.app.Fragment
@@ -115,6 +116,7 @@ class FilesystemEditFragment : Fragment() {
 
         setupTextInputs()
         setupImportButton()
+        setupAdvancedOptionButton()
 
         if (editExisting) {
             spinner_filesystem_type.isEnabled = false
@@ -129,7 +131,7 @@ class FilesystemEditFragment : Fragment() {
         }
     }
 
-    fun setupTextInputs() {
+    private fun setupTextInputs() {
         input_filesystem_name.setText(filesystem.name)
         input_filesystem_username.setText(filesystem.defaultUsername)
         input_filesystem_password.setText(filesystem.defaultPassword)
@@ -199,6 +201,23 @@ class FilesystemEditFragment : Fragment() {
         }
     }
 
+    private fun setupAdvancedOptionButton() {
+        val btn = btn_show_advanced_options
+
+        btn.setOnClickListener {
+            when (btn.isChecked) {
+                true -> {
+                    btn.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_keyboard_arrow_down_white_24dp, 0)
+                    advanced_options.visibility = View.VISIBLE
+                }
+                false -> {
+                    btn.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_keyboard_arrow_right_white_24dp, 0)
+                    advanced_options.visibility = View.GONE
+                }
+            }
+        }
+    }
+
     @TargetApi(Build.VERSION_CODES.M)
     private fun showPermissionsNecessaryDialog() {
         val builder = AlertDialog.Builder(activityContext)
@@ -222,7 +241,8 @@ class FilesystemEditFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, returnIntent)
         if (requestCode == IMPORT_FILESYSTEM_REQUEST_CODE) {
             returnIntent?.data?.let { uri ->
-                filesystemEditViewModel.backupUri = uri
+                filesystemEditViewModel.setBackupUri(uri)
+                text_backup_filename.text = uri.lastPathSegment
             }
         }
     }

--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -42,6 +42,8 @@ class FilesystemEditFragment : Fragment() {
 
     private lateinit var activityContext: MainActivity
 
+    private val IMPORT_FILESYSTEM_REQUEST_CODE = 5
+
     private val filesystem: Filesystem by lazy {
         arguments?.getParcelable("filesystem") as Filesystem
     }
@@ -57,8 +59,8 @@ class FilesystemEditFragment : Fragment() {
     private val filesystemImportStatusObserver = Observer<FilesystemImportStatus> {
         it?.let { importStatus ->
             when (importStatus) {
-                is ImportSuccess -> Toast.makeText(activityContext, "Successfully imported backup", Toast.LENGTH_LONG).show()
-                is ImportFailure -> Toast.makeText(activityContext, "Unable to import backup", Toast.LENGTH_LONG).show()
+                is ImportSuccess -> Toast.makeText(activityContext, R.string.import_success, Toast.LENGTH_LONG).show()
+                is ImportFailure -> Toast.makeText(activityContext, R.string.import_failure, Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -185,7 +187,7 @@ class FilesystemEditFragment : Fragment() {
             val filePickerIntent = Intent(Intent.ACTION_GET_CONTENT)
             filePickerIntent.addCategory(Intent.CATEGORY_OPENABLE)
             filePickerIntent.type = "application/*"
-            val fileChooser = Intent.createChooser(filePickerIntent, "Select Filesystem Backup file")
+            val fileChooser = Intent.createChooser(filePickerIntent, getString(R.string.prompt_select_backup))
             if (!arePermissionsGranted(activityContext)) {
                 showPermissionsNecessaryDialog()
                 return@setOnClickListener
@@ -195,7 +197,7 @@ class FilesystemEditFragment : Fragment() {
                 filesystem.isCreatedFromBackup = true
                 startActivityForResult(fileChooser, IMPORT_FILESYSTEM_REQUEST_CODE)
             } catch (activityNotFoundErr: ActivityNotFoundException) {
-                Toast.makeText(activityContext, "Please install a File Manager.", Toast.LENGTH_LONG).show()
+                Toast.makeText(activityContext, R.string.prompt_install_file_manager, Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -300,9 +302,5 @@ class FilesystemEditFragment : Fragment() {
                 return true
         }
         return false
-    }
-
-    companion object {
-        const val IMPORT_FILESYSTEM_REQUEST_CODE = 5
     }
 }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -58,11 +58,11 @@ class FilesystemListFragment : Fragment() {
                     activityContext.updateExportProgress(exportStatus.details)
                 }
                 is ExportSuccess -> {
-                    Toast.makeText(activityContext, "Successfully exported backup", Toast.LENGTH_LONG).show()
+                    Toast.makeText(activityContext, R.string.export_success, Toast.LENGTH_LONG).show()
                     activityContext.stopExportProgress()
                 }
                 is ExportFailure -> {
-                    Toast.makeText(activityContext, "Unable to exported backup: ${exportStatus.reason}", Toast.LENGTH_LONG).show()
+                    Toast.makeText(activityContext, "${R.string.export_failure} + ${exportStatus.reason}", Toast.LENGTH_LONG).show()
                     activityContext.stopExportProgress()
                 }
             }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -1,5 +1,6 @@
 package tech.ula.ui
 
+import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
@@ -12,7 +13,6 @@ import androidx.navigation.fragment.NavHostFragment
 import kotlinx.android.synthetic.main.frag_filesystem_list.* // ktlint-disable no-wildcard-imports
 import org.jetbrains.anko.bundleOf
 import org.jetbrains.anko.defaultSharedPreferences
-import tech.ula.MainActivity
 import tech.ula.R
 import tech.ula.ServerService
 import tech.ula.model.entities.Filesystem
@@ -26,15 +26,7 @@ import java.io.File
 
 class FilesystemListFragment : Fragment() {
 
-    interface FilesystemExport {
-        fun filesystemExportSelected(filesystem: Filesystem)
-    }
-
-    private val doOnFilesystemExport: FilesystemExport by lazy {
-        activityContext
-    }
-
-    private lateinit var activityContext: MainActivity
+    private lateinit var activityContext: Activity
 
     private lateinit var filesystemList: List<Filesystem>
 
@@ -77,7 +69,7 @@ class FilesystemListFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        activityContext = activity!! as MainActivity
+        activityContext = activity!!
         filesystemListViewModel.getAllFilesystems().observe(viewLifecycleOwner, filesystemChangeObserver)
         registerForContextMenu(list_filesystems)
     }
@@ -118,11 +110,9 @@ class FilesystemListFragment : Fragment() {
     }
 
     private fun exportFilesystem(filesystem: Filesystem): Boolean {
-        doOnFilesystemExport.filesystemExportSelected(filesystem)
-
         // TODO: Add real listener
         val statelessListener: (line: String) -> Unit = { }
-        val destination = File(Environment.getExternalStorageDirectory().path)
+        val destination = File(Environment.getExternalStorageDirectory().absolutePath)
         filesystemListViewModel.compressFilesystem(filesystem, destination, statelessListener)
 
         return true

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -1,6 +1,5 @@
 package tech.ula.ui
 
-import android.app.Activity
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
@@ -12,7 +11,6 @@ import android.widget.AdapterView
 import android.widget.Toast
 import androidx.navigation.fragment.NavHostFragment
 import kotlinx.android.synthetic.main.frag_filesystem_list.* // ktlint-disable no-wildcard-imports
-import kotlinx.coroutines.*
 import org.jetbrains.anko.bundleOf
 import org.jetbrains.anko.defaultSharedPreferences
 import tech.ula.MainActivity
@@ -33,7 +31,7 @@ import java.io.File
 class FilesystemListFragment : Fragment() {
 
     interface ExportFilesystem {
-        val getProgressBarAsListener:(String) -> Unit
+        val getProgressBarAsListener: (String) -> Unit
         fun stopProgressBar()
     }
 
@@ -103,7 +101,7 @@ class FilesystemListFragment : Fragment() {
         activityContext.menuInflater.inflate(R.menu.context_menu_filesystems, menu)
     }
 
-     override fun onContextItemSelected(item: MenuItem): Boolean {
+    override fun onContextItemSelected(item: MenuItem): Boolean {
         val menuInfo = item.menuInfo as AdapterView.AdapterContextMenuInfo
         val position = menuInfo.position
         val filesystem = filesystemList[position]

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -21,8 +21,7 @@ import tech.ula.model.repositories.UlaDatabase
 import tech.ula.utils.BusyboxExecutor
 import tech.ula.utils.DefaultPreferences
 import tech.ula.utils.FilesystemUtility
-import tech.ula.viewmodel.*
-import java.io.File
+import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 
 class FilesystemListFragment : Fragment() {
 

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -65,6 +65,9 @@ class FilesystemListFragment : Fragment() {
                     Toast.makeText(activityContext, "${R.string.export_failure} + ${exportStatus.reason}", Toast.LENGTH_LONG).show()
                     activityContext.stopExportProgress()
                 }
+                is ExportStarted -> {
+                    Toast.makeText(activityContext, R.string.export_started, Toast.LENGTH_LONG).show()
+                }
             }
         }
     }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -1,5 +1,6 @@
 package tech.ula.ui
 
+import android.app.AlertDialog
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
@@ -62,11 +63,12 @@ class FilesystemListFragment : Fragment() {
                     activityContext.stopExportProgress()
                 }
                 is ExportFailure -> {
-                    Toast.makeText(activityContext, "${R.string.export_failure} + ${exportStatus.reason}", Toast.LENGTH_LONG).show()
+                    val dialogBuilder = AlertDialog.Builder(activityContext)
+                    dialogBuilder.setMessage(getString(R.string.export_failure) + "\n${exportStatus.reason}").create().show()
                     activityContext.stopExportProgress()
                 }
                 is ExportStarted -> {
-                    Toast.makeText(activityContext, R.string.export_started, Toast.LENGTH_LONG).show()
+                    activityContext.updateExportProgress(getString(R.string.export_started))
                 }
             }
         }

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -61,14 +61,13 @@ class FilesystemUtility(
         }
     }
 
-    suspend fun compressFilesystem(filesystem: Filesystem, destinationPath: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
+    suspend fun compressFilesystem(filesystem: Filesystem, destinationPath: File, listener: (String) -> Any) = withContext(Dispatchers.Main) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
         if (!destinationPath.exists()) destinationPath.mkdirs()
         val destinationFile = "${destinationPath.path}/rootfs.tar.gz"
         val env = HashMap<String, String>()
         env["TAR_PATH"] = destinationFile
-
 
         val result = busyboxExecutor.executeProotCommand(
                 command,

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -61,17 +61,14 @@ class FilesystemUtility(
         }
     }
 
-    suspend fun compressFilesystem(filesystem: Filesystem, externalStorageDirectory: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
+    suspend fun compressFilesystem(filesystem: Filesystem, destinationPath: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
+        if (!destinationPath.exists()) destinationPath.mkdirs()
+        val destinationFile = "${destinationPath.path}/rootfs.tar.gz"
+        val env = HashMap<String, String>()
+        env["TAR_PATH"] = destinationFile
 
-        val externalUserlandDirPath = "${externalStorageDirectory.absolutePath}/UserLAnd"
-        if (!File(externalUserlandDirPath).exists())
-            File(externalUserlandDirPath).mkdirs()
-
-        val backupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
-        val backupTarget = "$externalUserlandDirPath/$backupName"
-        val env = hashMapOf("TAR_PATH" to backupTarget)
 
         val result = busyboxExecutor.executeProotCommand(
                 command,

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -61,13 +61,13 @@ class FilesystemUtility(
         }
     }
 
-    suspend fun compressFilesystem(filesystem: Filesystem, destinationPath: File, listener: (String) -> Any) = withContext(Dispatchers.Main) {
+    suspend fun compressFilesystem(filesystem: Filesystem, destinationFile: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
-        if (!destinationPath.exists()) destinationPath.mkdirs()
-        val destinationFile = "${destinationPath.path}/rootfs.tar.gz"
+        if (!destinationFile.exists()) destinationFile.mkdirs()
+        val destinationPath = "${destinationFile.path}/rootfs.tar.gz"
         val env = HashMap<String, String>()
-        env["TAR_PATH"] = destinationFile
+        env["TAR_PATH"] = destinationPath
 
         val result = busyboxExecutor.executeProotCommand(
                 command,

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -61,13 +61,11 @@ class FilesystemUtility(
         }
     }
 
-    suspend fun compressFilesystem(filesystem: Filesystem, destinationFile: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
+    suspend fun compressFilesystem(filesystem: Filesystem, localDestinationFile: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
-        if (!destinationFile.exists()) destinationFile.mkdirs()
-        val destinationPath = "${destinationFile.path}/rootfs.tar.gz"
         val env = HashMap<String, String>()
-        env["TAR_PATH"] = destinationPath
+        env["TAR_PATH"] = localDestinationFile.absolutePath
 
         val result = busyboxExecutor.executeProotCommand(
                 command,

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -61,7 +61,11 @@ class FilesystemUtility(
         }
     }
 
-    suspend fun compressFilesystem(filesystem: Filesystem, localDestinationFile: File, listener: (String) -> Any) = withContext(Dispatchers.IO) {
+    suspend fun compressFilesystem(
+        filesystem: Filesystem,
+        localDestinationFile: File,
+        listener: (String) -> Any
+    ): Boolean = withContext(Dispatchers.IO) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
         val env = HashMap<String, String>()
@@ -77,7 +81,9 @@ class FilesystemUtility(
         if (result is FailedExecution) {
             val err = result.reason
             logger.logRuntimeErrorForCommand(functionName = "compressFilesystem", command = command, err = err)
+            return@withContext false
         }
+        true
     }
 
     fun isExtractionComplete(targetDirectoryName: String): Boolean {

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -65,7 +65,7 @@ class FilesystemUtility(
         filesystem: Filesystem,
         localDestinationFile: File,
         listener: (String) -> Any
-    ): Boolean = withContext(Dispatchers.IO) {
+    ) = withContext(Dispatchers.IO) {
         val filesystemDirName = "${filesystem.id}"
         val command = "/support/common/compressFilesystem.sh"
         val env = HashMap<String, String>()
@@ -81,9 +81,7 @@ class FilesystemUtility(
         if (result is FailedExecution) {
             val err = result.reason
             logger.logRuntimeErrorForCommand(functionName = "compressFilesystem", command = command, err = err)
-            return@withContext false
         }
-        true
     }
 
     fun isExtractionComplete(targetDirectoryName: String): Boolean {

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -66,6 +66,9 @@ class FilesystemUtility(
         val command = "/support/common/compressFilesystem.sh"
 
         val externalUserlandDirPath = "${externalStorageDirectory.absolutePath}/UserLAnd"
+        if (!File(externalUserlandDirPath).exists())
+            File(externalUserlandDirPath).mkdirs()
+
         val backupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
         val backupTarget = "$externalUserlandDirPath/$backupName"
         val env = hashMapOf("TAR_PATH" to backupTarget)

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
@@ -1,12 +1,23 @@
 package tech.ula.viewmodel
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
+import android.content.ContentResolver
+import android.net.Uri
 import kotlinx.coroutines.* // ktlint-disable no-wildcard-imports
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.model.entities.Filesystem
 import java.io.File
+import java.io.FileOutputStream
+import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
+
+sealed class FilesystemImportStatus
+object ImportSuccess : FilesystemImportStatus()
+object UriUnselected : FilesystemImportStatus()
+data class ImportFailure(val reason: String) : FilesystemImportStatus()
 
 class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(), CoroutineScope {
     private val job = Job()
@@ -18,6 +29,14 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         super.onCleared()
     }
 
+    private val importStatusLiveData = MutableLiveData<FilesystemImportStatus>()
+
+    var backupUri: Uri? = null
+
+    fun getImportStatusLiveData(): LiveData<FilesystemImportStatus> {
+        return importStatusLiveData
+    }
+
     fun insertFilesystem(filesystem: Filesystem, coroutineScope: CoroutineScope = this) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
             ulaDatabase.filesystemDao().insertFilesystem(filesystem)
@@ -25,21 +44,42 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
     }
 
     fun insertFilesystemFromBackup(
+        contentResolver: ContentResolver,
         filesystem: Filesystem,
-        backupPath: String,
         filesDir: File,
         coroutineScope: CoroutineScope = this
     ) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
-            filesystem.isCreatedFromBackup = true
-            val id = ulaDatabase.filesystemDao().insertFilesystem(filesystem)
+            if (backupUri == null) {
+                importStatusLiveData.postValue(UriUnselected)
+                return@withContext
+            }
 
-            val filesystemSupportDir = File("${filesDir.absolutePath}/$id/support")
-            filesystemSupportDir.mkdirs()
+            try {
+                filesystem.isCreatedFromBackup = true
+                val id = ulaDatabase.filesystemDao().insertFilesystem(filesystem)
+                val filesystemSupportDir = File("${filesDir.absolutePath}/$id/support")
+                filesystemSupportDir.mkdirs()
+                val destination = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
 
-            val backup = File(backupPath)
-            val backupTarget = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
-            backup.copyTo(backupTarget, overwrite = true)
+                val inputStream = contentResolver.openInputStream(backupUri!!)
+                if (inputStream == null) {
+                    importStatusLiveData.postValue(ImportFailure("Could not open input stream"))
+                    return@withContext
+                }
+
+                val streamOutput = FileOutputStream(destination)
+                inputStream.use { input ->
+                    streamOutput.use { fileOut ->
+                        input!!.copyTo(fileOut)
+                    }
+                }
+            } catch (e: Exception) {
+                importStatusLiveData.postValue(ImportFailure(e.toString()))
+            }
+
+            backupUri = null
+            importStatusLiveData.postValue(ImportSuccess)
         }
     }
 

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
@@ -31,7 +31,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
 
     private val importStatusLiveData = MutableLiveData<FilesystemImportStatus>()
 
-    private var backupUri: Uri? = null
+    var backupUri: Uri? = null
 
     fun getImportStatusLiveData(): LiveData<FilesystemImportStatus> {
         return importStatusLiveData
@@ -41,14 +41,6 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         withContext(Dispatchers.IO) {
             ulaDatabase.filesystemDao().insertFilesystem(filesystem)
         }
-    }
-
-    fun getBackupUri(): Uri? {
-        return backupUri
-    }
-
-    fun setBackupUri(uri: Uri?) {
-        backupUri = uri
     }
 
     fun insertFilesystemFromBackup(
@@ -71,7 +63,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 filesystemSupportDir.mkdirs()
                 val destination = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
 
-                val inputStream = contentResolver.openInputStream(backupUri)
+                val inputStream = contentResolver.openInputStream(backupUri!!)
                 if (inputStream == null) {
                     ulaDatabase.filesystemDao().deleteFilesystemById(id)
                     importStatusLiveData.postValue(ImportFailure("Could not open input stream"))
@@ -89,7 +81,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 importStatusLiveData.postValue(ImportFailure(e.toString()))
             }
 
-            setBackupUri(null)
+            backupUri = null
             importStatusLiveData.postValue(ImportSuccess)
         }
     }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
@@ -47,7 +47,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         return backupUri
     }
 
-    fun setBackupUri(uri: Uri) {
+    fun setBackupUri(uri: Uri?) {
         backupUri = uri
     }
 
@@ -55,10 +55,11 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         contentResolver: ContentResolver,
         filesystem: Filesystem,
         filesDir: File,
+        backupUri: Uri?,
         coroutineScope: CoroutineScope = this
     ) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
-            if (getBackupUri() == null) {
+            if (backupUri == null) {
                 importStatusLiveData.postValue(UriUnselected)
                 return@withContext
             }
@@ -70,7 +71,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 filesystemSupportDir.mkdirs()
                 val destination = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
 
-                val inputStream = contentResolver.openInputStream(getBackupUri()!!)
+                val inputStream = contentResolver.openInputStream(backupUri)
                 if (inputStream == null) {
                     importStatusLiveData.postValue(ImportFailure("Could not open input stream"))
                     return@withContext
@@ -86,7 +87,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 importStatusLiveData.postValue(ImportFailure(e.toString()))
             }
 
-            backupUri = null
+            setBackupUri(null)
             importStatusLiveData.postValue(ImportSuccess)
         }
     }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
@@ -31,7 +31,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
 
     private val importStatusLiveData = MutableLiveData<FilesystemImportStatus>()
 
-    var backupUri: Uri? = null
+    private var backupUri: Uri? = null
 
     fun getImportStatusLiveData(): LiveData<FilesystemImportStatus> {
         return importStatusLiveData
@@ -43,6 +43,14 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         }
     }
 
+    fun getBackupUri(): Uri? {
+        return backupUri
+    }
+
+    fun setBackupUri(uri: Uri) {
+        backupUri = uri
+    }
+
     fun insertFilesystemFromBackup(
         contentResolver: ContentResolver,
         filesystem: Filesystem,
@@ -50,7 +58,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
         coroutineScope: CoroutineScope = this
     ) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
-            if (backupUri == null) {
+            if (getBackupUri() == null) {
                 importStatusLiveData.postValue(UriUnselected)
                 return@withContext
             }
@@ -62,7 +70,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 filesystemSupportDir.mkdirs()
                 val destination = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
 
-                val inputStream = contentResolver.openInputStream(backupUri!!)
+                val inputStream = contentResolver.openInputStream(getBackupUri()!!)
                 if (inputStream == null) {
                     importStatusLiveData.postValue(ImportFailure("Could not open input stream"))
                     return@withContext

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -63,9 +63,9 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
             val localTempBackupFile = File("${filesDir.path}/rootfs.tar.gz")
             if (!externalStorageDirectory.exists()) externalStorageDirectory.mkdirs()
 
-            filesystemUtility.compressFilesystem(filesystem, localTempBackupFile, exportUpdateListener)
+            val compressSuccess = filesystemUtility.compressFilesystem(filesystem, localTempBackupFile, exportUpdateListener)
 
-            if (!localTempBackupFile.exists()) {
+            if (!compressSuccess) {
                 exportStatusLiveData.postValue(ExportFailure("Exporting to local directory failed"))
                 return@withContext
             }
@@ -74,7 +74,7 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
                 localTempBackupFile.copyTo(externalBackupFile)
                 localTempBackupFile.delete()
             } catch (e: Exception) {
-                exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed: $e"))
+                exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
                 localTempBackupFile.delete()
                 return@withContext
             }
@@ -82,7 +82,7 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
             when (externalBackupFile.exists() && externalBackupFile.length() > 0) {
                 true -> exportStatusLiveData.postValue(ExportSuccess)
                 false -> {
-                    exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
+                    exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed, exported file has no data"))
                     localTempBackupFile.delete()
                 }
             }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -9,7 +9,6 @@ import tech.ula.model.daos.FilesystemDao
 import tech.ula.model.entities.Filesystem
 import tech.ula.utils.FilesystemUtility
 import java.io.File
-import java.io.FileOutputStream
 import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
@@ -75,13 +74,11 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
                 localTempBackupFile.copyTo(externalBackupFile)
                 localTempBackupFile.delete()
             } catch (e: Exception) {
-                exportStatusLiveData.postValue(ExportFailure(e.toString()))
+                exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
+                localTempBackupFile.delete()
+                return@withContext
             }
-
-            when (externalBackupFile.exists()) {
-                true -> exportStatusLiveData.postValue(ExportSuccess)
-                false -> exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
-            }
+            exportStatusLiveData.postValue(ExportSuccess)
         }
     }
 }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -16,6 +16,7 @@ sealed class FilesystemExportStatus
 data class ExportUpdate(val details: String) : FilesystemExportStatus()
 object ExportSuccess : FilesystemExportStatus()
 data class ExportFailure(val reason: String) : FilesystemExportStatus()
+object ExportStarted : FilesystemExportStatus()
 
 class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private val filesystemUtility: FilesystemUtility) : ViewModel(), CoroutineScope {
 
@@ -58,6 +59,7 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
         coroutineScope: CoroutineScope = this
     ) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
+            exportStatusLiveData.postValue(ExportStarted)
             val backupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
             val externalBackupFile = File("${externalStorageDirectory.path}/$backupName")
             val localTempBackupFile = File("${filesDir.path}/rootfs.tar.gz")

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -74,11 +74,18 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
                 localTempBackupFile.copyTo(externalBackupFile)
                 localTempBackupFile.delete()
             } catch (e: Exception) {
-                exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
+                exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed: $e"))
                 localTempBackupFile.delete()
                 return@withContext
             }
-            exportStatusLiveData.postValue(ExportSuccess)
+
+            when (externalBackupFile.exists() && externalBackupFile.length() > 0) {
+                true -> exportStatusLiveData.postValue(ExportSuccess)
+                false -> {
+                    exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed"))
+                    localTempBackupFile.delete()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -1,6 +1,7 @@
 package tech.ula.viewmodel
 
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import kotlinx.coroutines.* // ktlint-disable no-wildcard-imports
@@ -8,7 +9,13 @@ import tech.ula.model.daos.FilesystemDao
 import tech.ula.model.entities.Filesystem
 import tech.ula.utils.FilesystemUtility
 import java.io.File
+import java.io.FileOutputStream
+import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
+
+sealed class FilesystemExportStatus
+object ExportSuccess : FilesystemExportStatus()
+data class ExportFailure(val reason: String) : FilesystemExportStatus()
 
 class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private val filesystemUtility: FilesystemUtility) : ViewModel(), CoroutineScope {
 
@@ -25,6 +32,12 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
         filesystemDao.getAllFilesystems()
     }
 
+    private val exportStatusLiveData = MutableLiveData<FilesystemExportStatus>()
+
+    fun getExportStatusLiveData(): LiveData<FilesystemExportStatus> {
+        return exportStatusLiveData
+    }
+
     fun getAllFilesystems(): LiveData<List<Filesystem>> {
         return filesystems
     }
@@ -37,11 +50,35 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
 
     fun compressFilesystem(
         filesystem: Filesystem,
+        localTempDirectory: File,
         externalStorageDirectory: File,
         listener: (String) -> Any,
         coroutineScope: CoroutineScope = this
     ) = coroutineScope.launch {
-        filesystemUtility.compressFilesystem(filesystem, externalStorageDirectory, listener)
+
+        val backupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
+        val externalDestinationUri = File("${externalStorageDirectory.path}/$backupName")
+        if (!externalStorageDirectory.exists()) externalStorageDirectory.mkdirs()
+
+        filesystemUtility.compressFilesystem(filesystem, File(localTempDirectory.path), listener)
+
+        if (!File(localTempDirectory.path).exists()) {
+            return@launch
+        }
+
+        val inputStream = File("$localTempDirectory/rootfs.tar.gz").inputStream()
+
+        try {
+            val streamOutput = FileOutputStream(externalDestinationUri)
+            inputStream.use { input ->
+                streamOutput.use { fileOut ->
+                    input.copyTo(fileOut)
+                }
+            }
+        } catch (e: Exception) {
+            exportStatusLiveData.postValue(ExportFailure(e.toString()))
+        }
+        exportStatusLiveData.postValue(ExportSuccess)
     }
 }
 

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -65,9 +65,9 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
             val localTempBackupFile = File("${filesDir.path}/rootfs.tar.gz")
             if (!externalStorageDirectory.exists()) externalStorageDirectory.mkdirs()
 
-            val compressSuccess = filesystemUtility.compressFilesystem(filesystem, localTempBackupFile, exportUpdateListener)
+            filesystemUtility.compressFilesystem(filesystem, localTempBackupFile, exportUpdateListener)
 
-            if (!compressSuccess) {
+            if (!localTempBackupFile.exists()) {
                 exportStatusLiveData.postValue(ExportFailure("Exporting to local directory failed"))
                 return@withContext
             }
@@ -83,10 +83,7 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
 
             when (externalBackupFile.exists() && externalBackupFile.length() > 0) {
                 true -> exportStatusLiveData.postValue(ExportSuccess)
-                false -> {
-                    exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed, exported file has no data"))
-                    localTempBackupFile.delete()
-                }
+                false -> exportStatusLiveData.postValue(ExportFailure("Exporting to external directory failed, exported file has no data"))
             }
         }
     }

--- a/app/src/main/res/drawable/ic_keyboard_arrow_down_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_down_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard_arrow_right_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_right_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M8.59,16.34l4.58,-4.59 -4.58,-4.59L10,5.75l6,6 -6,6z"/>
+</vector>

--- a/app/src/main/res/layout/frag_filesystem_edit.xml
+++ b/app/src/main/res/layout/frag_filesystem_edit.xml
@@ -97,5 +97,19 @@
             app:layout_constraintStart_toEndOf="@id/text_filesystem_type"
             app:layout_constraintTop_toBottomOf="@id/text_input_layout_filesystem_vncpasswd" />
 
+        <Button
+            android:id="@+id/import_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Import filesystem"
+            android:orientation="horizontal"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/spinner_filesystem_type"
+            app:layout_constraintStart_toEndOf="@id/text_filesystem_type"
+            app:layout_constraintEnd_toEndOf="@id/text_filesystem_type"
+            />
+
     </android.support.constraint.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/frag_filesystem_edit.xml
+++ b/app/src/main/res/layout/frag_filesystem_edit.xml
@@ -101,8 +101,8 @@
             android:id="@+id/btn_show_advanced_options"
             android:background="?android:attr/selectableItemBackground"
             android:checked="false"
-            android:textOn="Show Advanced Options"
-            android:textOff="Hide Advanced Options"
+            android:textOn="@string/button_advanced_options_hide"
+            android:textOff="@string/button_advanced_options_show"
             android:textColor="@color/colorAccent"
             android:drawableEnd="@drawable/ic_keyboard_arrow_right_white_24dp"
             android:layout_width="wrap_content"
@@ -119,13 +119,12 @@
             android:layout_height="wrap_content"
             android:visibility="gone"
             android:orientation="vertical"
-            app:layout_constraintTop_toBottomOf="@id/btn_show_advanced_options"
-            >
+            app:layout_constraintTop_toBottomOf="@id/btn_show_advanced_options" >
             <TextView
                 android:id="@+id/text_backup_filename"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="No filesystem import detected"
+                android:text="@string/no_backup_selected"
                 android:layout_gravity="center_horizontal"
                 android:padding="8dp" />
 
@@ -133,7 +132,7 @@
                 android:id="@+id/import_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Select backup file to import"
+                android:text="@string/button_select_backup_import"
                 android:orientation="horizontal"
                 android:layout_gravity="center_horizontal"
                 android:padding="16dp"

--- a/app/src/main/res/layout/frag_filesystem_edit.xml
+++ b/app/src/main/res/layout/frag_filesystem_edit.xml
@@ -97,19 +97,47 @@
             app:layout_constraintStart_toEndOf="@id/text_filesystem_type"
             app:layout_constraintTop_toBottomOf="@id/text_input_layout_filesystem_vncpasswd" />
 
-        <Button
-            android:id="@+id/import_button"
+        <ToggleButton
+            android:id="@+id/btn_show_advanced_options"
+            android:background="?android:attr/selectableItemBackground"
+            android:checked="false"
+            android:textOn="Show Advanced Options"
+            android:textOff="Hide Advanced Options"
+            android:textColor="@color/colorAccent"
+            android:drawableEnd="@drawable/ic_keyboard_arrow_right_white_24dp"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginTop="32dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/spinner_filesystem_type"
+            app:layout_constraintStart_toStartOf="@+id/text_input_layout" />
+
+        <LinearLayout
+            android:id="@+id/advanced_options"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="Import filesystem"
-            android:orientation="horizontal"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            app:layout_constraintTop_toBottomOf="@+id/spinner_filesystem_type"
-            app:layout_constraintStart_toEndOf="@id/text_filesystem_type"
-            app:layout_constraintEnd_toEndOf="@id/text_filesystem_type"
-            />
+            android:visibility="gone"
+            android:orientation="vertical"
+            app:layout_constraintTop_toBottomOf="@id/btn_show_advanced_options"
+            >
+            <TextView
+                android:id="@+id/text_backup_filename"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="No filesystem import detected"
+                android:layout_gravity="center_horizontal"
+                android:padding="8dp" />
 
+            <Button
+                android:id="@+id/import_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Select backup file to import"
+                android:orientation="horizontal"
+                android:layout_gravity="center_horizontal"
+                android:padding="16dp"
+                />
+        </LinearLayout>
     </android.support.constraint.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/menu/context_menu_filesystems.xml
+++ b/app/src/main/res/menu/context_menu_filesystems.xml
@@ -8,4 +8,8 @@
         android:id="@+id/menu_item_filesystem_delete"
         android:title="@string/delete" />
 
+    <item
+        android:id="@+id/menu_item_filesystem_export"
+        android:title="@string/backup" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,7 @@
     <string name="import_failure">Unable to import backup</string>
     <string name="export_success">Successfully exported backup</string>
     <string name="export_failure">Unable to export backup</string>
+    <string name="export_started">Export started, please wait</string>
 
     <!-- Clear support files alert -->
     <string name="alert_clear_support_files_title">Clear all support files?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="kill_service">Kill Service</string>               <!-- We know this says name="kill_service" but it is really stopping a session. -->
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
+    <string name="backup">Export</string>
     <string name="save">Save</string>
     <string name="add">Add</string>
     <string name="refresh">Refresh</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="prompt_service_type">Service Type:</string>
     <string name="prompt_client_type">Client Type:</string>
     <string name="prompt_app_connection_type_preference">Please select a connection type: </string>
+    <string name="prompt_select_backup">Select filesystem backup file</string>
+    <string name="prompt_install_file_manager">Please install a File Manager</string>
 
     <!-- Notification strings -->
     <string name="services_notification_channel_id">UserLAndServices</string>
@@ -149,6 +151,10 @@
     <string name="general_error_title">Something unexpected happened!</string>
     <string name="filesystem_credentials_reasoning">We\'re creating a filesystem for your apps.\nPlease enter the relevant required information for us to use as defaults for this filesystem.</string>
     <string name="deactivate_sessions">All sessions need to be deactivated to continue this action.</string>
+    <string name="import_success">Successfully imported backup</string>
+    <string name="import_failure">Unable to import backup</string>
+    <string name="export_success">Successfully exported backup</string>
+    <string name="export_failure">Unable to export backup</string>
 
     <!-- Clear support files alert -->
     <string name="alert_clear_support_files_title">Clear all support files?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,9 @@
 
     <!-- Buttons -->
     <string name="button_continue">Continue</string>
+    <string name="button_advanced_options_show">Show Advanced Options</string>
+    <string name="button_advanced_options_hide">Hide Advanced Options</string>
+    <string name="button_select_backup_import">Select backup file to import</string>
 
     <!-- Menus -->
     <string name="app_info">App Info</string>
@@ -189,6 +192,7 @@
     <string name="custom_sessions">Custom Sessions</string>
     <string name="apps_sessions">Apps Sessions</string>
     <string name="info_xsdl_support">XSDL is not fully supported on \nAndroid 9.0 and above yet</string>
+    <string name="no_backup_selected">No filesystem import selected</string>
     
     <!-- Review request -->
     <string name="review_is_user_enjoying">Enjoying UserLAnd?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="progress_verifying_assets">Verifying assets&#8230;</string>
     <string name="progress_starting">Starting service&#8230;</string>
     <string name="progress_clearing_support_files">Clearing all support files&#8230;</string>
+    <string name="progress_exporting_filesystem">Exporting filesystem</string>
 
     <!-- Preferences -->
     <string name="pref_app_category">App Preferences</string>

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -108,8 +108,8 @@ class FilesystemUtilityTest {
         val filesystem = Filesystem(id = 0, name = "backup", distributionType = "distType")
         val externalStorageDirectory = tempFolder.root
 
-        val expectedBackupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
-        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/UserLAnd/$expectedBackupName"
+        val expectedBackupName = "rootfs.tar.gz"
+        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/$expectedBackupName"
         val expectedEnv = hashMapOf("TAR_PATH" to expectedBackupPath)
 
         whenever(mockBusyboxExecutor.executeProotCommand(
@@ -139,8 +139,8 @@ class FilesystemUtilityTest {
         val filesystem = Filesystem(id = 0, name = "backup", distributionType = "distType")
         val externalStorageDirectory = tempFolder.root
 
-        val expectedBackupName = "${filesystem.name}-${filesystem.distributionType}-rootfs.tar.gz"
-        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/UserLAnd/$expectedBackupName"
+        val expectedBackupName = "rootfs.tar.gz"
+        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/$expectedBackupName"
         val expectedEnv = hashMapOf("TAR_PATH" to expectedBackupPath)
 
         val failureReason = "reason"
@@ -154,7 +154,9 @@ class FilesystemUtilityTest {
         ))
                 .thenReturn(FailedExecution(failureReason))
 
-        runBlocking { filesystemUtility.compressFilesystem(filesystem, externalStorageDirectory, statelessListener) }
+        runBlocking {
+            filesystemUtility.compressFilesystem(filesystem, externalStorageDirectory, statelessListener)
+        }
 
         verify(logger).logRuntimeErrorForCommand("compressFilesystem", command, failureReason)
     }

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -108,9 +108,9 @@ class FilesystemUtilityTest {
         val filesystem = Filesystem(id = 0, name = "backup", distributionType = "distType")
         val externalStorageDirectory = tempFolder.root
 
-        val expectedBackupName = "rootfs.tar.gz"
-        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/$expectedBackupName"
-        val expectedEnv = hashMapOf("TAR_PATH" to expectedBackupPath)
+        val destinationName = "rootfs.tar.gz"
+        val destinationPath = "${externalStorageDirectory.absolutePath}/$destinationName"
+        val expectedEnv = hashMapOf("TAR_PATH" to destinationPath)
 
         whenever(mockBusyboxExecutor.executeProotCommand(
                 eq(command),
@@ -122,7 +122,7 @@ class FilesystemUtilityTest {
         ))
                 .thenReturn(SuccessfulExecution)
 
-        runBlocking { filesystemUtility.compressFilesystem(filesystem, externalStorageDirectory, statelessListener) }
+        runBlocking { filesystemUtility.compressFilesystem(filesystem, File(destinationPath), statelessListener) }
         verify(mockBusyboxExecutor).executeProotCommand(
                 eq(command),
                 eq("${filesystem.id}"),
@@ -139,9 +139,9 @@ class FilesystemUtilityTest {
         val filesystem = Filesystem(id = 0, name = "backup", distributionType = "distType")
         val externalStorageDirectory = tempFolder.root
 
-        val expectedBackupName = "rootfs.tar.gz"
-        val expectedBackupPath = "${externalStorageDirectory.absolutePath}/$expectedBackupName"
-        val expectedEnv = hashMapOf("TAR_PATH" to expectedBackupPath)
+        val destinationName = "rootfs.tar.gz"
+        val destinationPath = "${externalStorageDirectory.absolutePath}/$destinationName"
+        val expectedEnv = hashMapOf("TAR_PATH" to destinationPath)
 
         val failureReason = "reason"
         whenever(mockBusyboxExecutor.executeProotCommand(
@@ -155,7 +155,7 @@ class FilesystemUtilityTest {
                 .thenReturn(FailedExecution(failureReason))
 
         runBlocking {
-            filesystemUtility.compressFilesystem(filesystem, externalStorageDirectory, statelessListener)
+            filesystemUtility.compressFilesystem(filesystem, File(destinationPath), statelessListener)
         }
 
         verify(logger).logRuntimeErrorForCommand("compressFilesystem", command, failureReason)

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
@@ -50,31 +50,32 @@ class FilesystemEditViewModelTest {
         verify(mockFilesystemDao).insertFilesystem(filesystem)
     }
 
-    @Test
-    fun `insertFilesystemFromBackup sets filesystem isCreatedFromBackup property and moves backup file to correct location`() {
-        val filesystem = Filesystem(id = 0, name = "test")
-        whenever(mockFilesystemDao.insertFilesystem(filesystem)).thenReturn(1)
-
-        val filesDir = tempFolder.root
-
-        val backupText = "this is test text"
-        val backupSourceFile = tempFolder.newFile("backupFile")
-        backupSourceFile.writeText(backupText)
-
-        val filesystemSupportDir = tempFolder.newFolder("1", "support")
-        val expectedBackupTargetFile = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
-
-        runBlocking {
-            filesystemEditViewModel.insertFilesystemFromBackup(filesystem, backupSourceFile.absolutePath, filesDir, this)
-        }
-
-        filesystem.isCreatedFromBackup = true
-        verify(mockFilesystemDao).insertFilesystem(filesystem)
-
-        val readBackupText = expectedBackupTargetFile.readText()
-        assertTrue(expectedBackupTargetFile.exists())
-        assertEquals(backupText, readBackupText)
-    }
+    // TODO: Fix test
+//    @Test
+//    fun `insertFilesystemFromBackup sets filesystem isCreatedFromBackup property and moves backup file to correct location`() {
+//        val filesystem = Filesystem(id = 0, name = "test")
+//        whenever(mockFilesystemDao.insertFilesystem(filesystem)).thenReturn(1)
+//
+//        val filesDir = tempFolder.root
+//
+//        val backupText = "this is test text"
+//        val backupSourceFile = tempFolder.newFile("backupFile")
+//        backupSourceFile.writeText(backupText)
+//
+//        val filesystemSupportDir = tempFolder.newFolder("1", "support")
+//        val expectedBackupTargetFile = File("${filesystemSupportDir.absolutePath}/rootfs.tar.gz")
+//
+//        runBlocking {
+//            filesystemEditViewModel.insertFilesystemFromBackup(filesystem, backupSourceFile.absolutePath, filesDir, this)
+//        }
+//
+//        filesystem.isCreatedFromBackup = true
+//        verify(mockFilesystemDao).insertFilesystem(filesystem)
+//
+//        val readBackupText = expectedBackupTargetFile.readText()
+//        assertTrue(expectedBackupTargetFile.exists())
+//        assertEquals(backupText, readBackupText)
+//    }
 
     @Test
     fun `updateFilesystem delegates to model and also delegates that sessionDao should update all session names`() {

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
@@ -66,7 +66,7 @@ class FilesystemEditViewModelTest {
     @Test
     fun `insertFilesystemFromBackup posts UriUnselected if uri has not been set`() {
         filesystemEditViewModel.getImportStatusLiveData().observeForever(mockObserver)
-        filesystemEditViewModel.setBackupUri(null)
+        filesystemEditViewModel.backupUri = null
 
         val filesystem = Filesystem(0)
 
@@ -81,7 +81,7 @@ class FilesystemEditViewModelTest {
     fun `insertFilesystemFromBackup removes db entry posts ImportFailure if input stream is null`() {
         val filesystem = Filesystem(0)
         filesystemEditViewModel.getImportStatusLiveData().observeForever(mockObserver)
-        filesystemEditViewModel.setBackupUri(mockBackupUri)
+        filesystemEditViewModel.backupUri = mockBackupUri
         whenever(mockFilesystemDao.insertFilesystem(filesystem))
                 .thenReturn(0)
         whenever(mockContentResolver.openInputStream(mockBackupUri))
@@ -99,7 +99,7 @@ class FilesystemEditViewModelTest {
     fun `insertFilesystemFromBackup removes db entry and posts ImportFailure if an exception is caught`() {
         val filesystem = Filesystem(0)
         filesystemEditViewModel.getImportStatusLiveData().observeForever(mockObserver)
-        filesystemEditViewModel.setBackupUri(mockBackupUri)
+        filesystemEditViewModel.backupUri = mockBackupUri
         whenever(mockFilesystemDao.insertFilesystem(filesystem))
                 .thenReturn(0)
         val exception = FileNotFoundException()
@@ -131,7 +131,7 @@ class FilesystemEditViewModelTest {
         whenever(mockContentResolver.openInputStream(mockBackupUri))
                 .thenReturn(backupSourceFile.inputStream())
 
-        filesystemEditViewModel.setBackupUri(mockBackupUri)
+        filesystemEditViewModel.backupUri = mockBackupUri
         filesystemEditViewModel.getImportStatusLiveData().observeForever(mockObserver)
         runBlocking {
             filesystemEditViewModel.insertFilesystemFromBackup(mockContentResolver, filesystem, filesDir, this)
@@ -144,7 +144,7 @@ class FilesystemEditViewModelTest {
         assertTrue(expectedBackupTargetFile.exists())
         assertEquals(backupText, readBackupText)
         verify(mockObserver).onChanged(ImportSuccess)
-        assertEquals(null, filesystemEditViewModel.getBackupUri())
+        assertEquals(null, filesystemEditViewModel.backupUri)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemEditViewModelTest.kt
@@ -2,8 +2,6 @@ package tech.ula.viewmodel
 
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -16,7 +14,6 @@ import tech.ula.model.daos.FilesystemDao
 import tech.ula.model.daos.SessionDao
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.repositories.UlaDatabase
-import java.io.File
 
 @RunWith(MockitoJUnitRunner::class)
 class FilesystemEditViewModelTest {

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
@@ -65,10 +65,11 @@ class FilesystemListViewModelTest {
     fun `compressFilesystem delegates to the model layer properly`() {
         val filesystem = Filesystem(id = 0)
         val testFile = File("fake")
+        val externalStorageFile = File("external/fake")
         val testListener: (String) -> Unit = {}
 
         runBlocking {
-            filesystemListViewModel.compressFilesystem(filesystem, testFile, testListener, this)
+            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, testFile, externalStorageFile, testListener, this)
         }
         verifyBlocking(mockFilesystemUtility) { compressFilesystem(filesystem, testFile, testListener) }
     }

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
@@ -3,13 +3,13 @@ package tech.ula.viewmodel
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyBlocking
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.* // ktlint-disable no-wildcard-imports
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -23,13 +23,22 @@ class FilesystemListViewModelTest {
 
     @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
 
+    @get:Rule val tempFolder = TemporaryFolder()
+
     @Mock lateinit var mockFilesystemDao: FilesystemDao
 
     @Mock lateinit var mockFilesystemUtility: FilesystemUtility
 
-    @Mock lateinit var mockObserver: Observer<List<Filesystem>>
+    @Mock lateinit var mockFsListObserver: Observer<List<Filesystem>>
+
+    @Mock lateinit var mockExportObserver: Observer<FilesystemExportStatus>
 
     private lateinit var filesystemsLiveData: MutableLiveData<List<Filesystem>>
+
+    private val filesystemName = "fsname"
+    private val filesystemType = "fstype"
+    private val rootfsString = "rootfs.tar.gz"
+    private val expectedBackupName = "$filesystemName-$filesystemType-$rootfsString"
 
     private lateinit var filesystemListViewModel: FilesystemListViewModel
 
@@ -46,10 +55,10 @@ class FilesystemListViewModelTest {
         val testFilesystemName = "test"
         val testFilesystemList = listOf(Filesystem(id = 0, name = testFilesystemName))
 
-        filesystemListViewModel.getAllFilesystems().observeForever(mockObserver)
+        filesystemListViewModel.getAllFilesystems().observeForever(mockFsListObserver)
         filesystemsLiveData.postValue(testFilesystemList)
 
-        verify(mockObserver).onChanged(testFilesystemList)
+        verify(mockFsListObserver).onChanged(testFilesystemList)
     }
 
     @Test
@@ -62,15 +71,59 @@ class FilesystemListViewModelTest {
     }
 
     @Test
-    fun `compressFilesystem delegates to the model layer properly`() {
-        val filesystem = Filesystem(id = 0)
-        val testFile = File("fake")
-        val externalStorageFile = File("external/fake")
-        val testListener: (String) -> Unit = {}
+    fun `compressFilesystem copies backup to external and posts ExportSuccess`() {
+        val filesystem = Filesystem(id = 0, name = filesystemName, distributionType = filesystemType)
+        val filesDir = tempFolder.newFolder("files")
+        val externalDir = tempFolder.newFolder("external")
 
+        val expectedLocalBackupFile = File("${filesDir.absolutePath}/$rootfsString")
+        expectedLocalBackupFile.createNewFile()
+
+        filesystemListViewModel.getExportStatusLiveData().observeForever(mockExportObserver)
         runBlocking {
-            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, testFile, externalStorageFile, testListener, this)
+            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
         }
-        verifyBlocking(mockFilesystemUtility) { compressFilesystem(filesystem, testFile, testListener) }
+
+        verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
+        verify(mockExportObserver).onChanged(ExportSuccess)
+    }
+
+    @Test
+    fun `compressFilesystem posts ExportFailure if the local backup is not created`() {
+        val filesystem = Filesystem(id = 0, name = filesystemName, distributionType = filesystemType)
+        val filesDir = tempFolder.newFolder("files")
+        val externalDir = tempFolder.newFolder("external")
+        val expectedLocalBackupFile = File("${filesDir.absolutePath}/$rootfsString")
+
+        assertFalse(expectedLocalBackupFile.exists())
+        filesystemListViewModel.getExportStatusLiveData().observeForever(mockExportObserver)
+        runBlocking {
+            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
+        }
+
+        verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
+        verify(mockExportObserver).onChanged(ExportFailure("Exporting to local directory failed"))
+    }
+
+    @Test
+    fun `compressFilesystem posts ExportFailure if a backup of the same name already exists externally`() {
+        val filesystem = Filesystem(id = 0, name = filesystemName, distributionType = filesystemType)
+        val filesDir = tempFolder.newFolder("files")
+        val externalDir = tempFolder.newFolder("external")
+
+        val expectedLocalBackupFile = File("${filesDir.absolutePath}/$rootfsString")
+        expectedLocalBackupFile.createNewFile()
+
+        val expectedExternalBackupFile = File("${externalDir.absolutePath}/$expectedBackupName")
+        expectedExternalBackupFile.createNewFile()
+
+        filesystemListViewModel.getExportStatusLiveData().observeForever(mockExportObserver)
+        runBlocking {
+            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
+        }
+
+        assertFalse(expectedLocalBackupFile.exists())
+        verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
+        verify(mockExportObserver).onChanged(ExportFailure("Exporting to external directory failed"))
     }
 }

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
@@ -78,12 +78,14 @@ class FilesystemListViewModelTest {
 
         val expectedLocalBackupFile = File("${filesDir.absolutePath}/$rootfsString")
         expectedLocalBackupFile.createNewFile()
+        expectedLocalBackupFile.writeText("test")
 
         filesystemListViewModel.getExportStatusLiveData().observeForever(mockExportObserver)
         runBlocking {
             filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
         }
 
+        verify(mockExportObserver).onChanged(ExportStarted)
         verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
         verify(mockExportObserver).onChanged(ExportSuccess)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     ext {
         kotlin_version = '1.3.11'
-        android_plugin = '3.3.0'
+        android_plugin = '3.3.2'
         ktlint_version = '0.29.0'
 
         support_library_version = '28.0.0'


### PR DESCRIPTION
**Describe the pull request**

Provide a description of the problem your pull request solves. Screenshots, code examples, etc are welcome in this section.

This will allow users to navigate to the filesystemListFragment and longpress an existing filesystem in order to export their filesystem off of UserLAnd.  

It will be stored in their external memory.   In the Kotlin code it will be saved via:
`Environment.getExternalStoragePublicDirectory("UserLAnd")`

Importing the same file to use it as a filesystem is also supported too, when in the FilesystemEditFragment menu, there will be a "Show Advanced Options" button.  

![Screen Shot 2019-03-12 at 12 06 34 PM](https://user-images.githubusercontent.com/11577853/54228387-4cd54b80-44bf-11e9-9e15-dad871cd245d.png)

Upon pressing it, the import button will be visible along with a description of what the user should fill out in the text fields above.

![Screen Shot 2019-03-12 at 12 07 02 PM](https://user-images.githubusercontent.com/11577853/54228427-5d85c180-44bf-11e9-9384-9df540fd2c2e.png)


**Link to relevant issues**
