### PR TITLE
Fix problem formatting text with images

### DIFF
--- a/app/src/main/res/layout/list_item_filesystem.xml
+++ b/app/src/main/res/layout/list_item_filesystem.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="72dp" >
 
@@ -28,4 +28,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
Fix problem formatting text with images for different languages

There are errors in formatting the text in some languages ​​written form the opposite side for English where the text appears on the image I have corrected this problem according to my experience modest

LinearLayout format is used because it prevents the appearance of elements above some and also determines the horizontal width instead of the vertical

Please review this edit on Android studio and make sure that it works as required in all languages. Or try to correct this problem by he is references

**The AIDE application was used**
![screenshot_2019-03-07-11-49-37](https://user-images.githubusercontent.com/27397889/53947782-1e2a3000-40cf-11e9-8cf0-fdf12791dd3c.png)
