### PR TITLE
For apps that only support GUI, show the preference dialog but disable SSH option

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -721,6 +721,11 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 xsdlSupportedText.visibility = View.VISIBLE
             }
 
+            if (!viewModel.lastSelectedApp.supportsCli) {
+                sshTypePreference.isEnabled = false
+                sshTypePreference.alpha = 0.5f
+            }
+
             customDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
                 customDialog.dismiss()
                 val selectedPreference = when {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -213,7 +213,7 @@ class AppsPreferences(private val prefs: SharedPreferences) {
         return when {
             pref.toLowerCase() == "ssh" || (app.supportsCli && !app.supportsGui) -> SshTypePreference
             pref.toLowerCase() == "xsdl" -> XsdlTypePreference
-            pref.toLowerCase() == "vnc" || (!app.supportsCli && app.supportsGui) -> VncTypePreference
+            pref.toLowerCase() == "vnc" -> VncTypePreference
             else -> PreferenceHasNotBeenSelected
         }
     }


### PR DESCRIPTION
**Describe the pull request**

This fix will solve the issue where selecting an app that supports only GUI (for example Inkscape), will automatically select VNC.

This PR will now change that behavior so it will show a dialog prompting VNC or XSDL (GUI options) with SSH disabled.

**Link to relevant issues**


![after selecting Inkscape](https://user-images.githubusercontent.com/11577853/54222164-15ac6d80-44b2-11e9-83aa-9830cbe1ee77.png)
