### PR TITLE
Do not allow exporting backup while session is active

### DIFF
--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -69,7 +69,7 @@ class FilesystemListFragment : Fragment() {
                 }
                 is ExportFailure -> {
                     val dialogBuilder = AlertDialog.Builder(activityContext)
-                    dialogBuilder.setMessage(getString(R.string.export_failure) + "\n${exportStatus.reason}").create().show()
+                    dialogBuilder.setMessage(getString(R.string.export_failure) + "\n" + getString(exportStatus.reason)).create().show()
                     activityContext.stopExportProgress()
                 }
                 is ExportStarted -> {
@@ -124,7 +124,7 @@ class FilesystemListFragment : Fragment() {
         return when (item.itemId) {
             R.id.menu_item_filesystem_edit -> editFilesystem(filesystem)
             R.id.menu_item_filesystem_delete -> deleteFilesystem(filesystem)
-            R.id.menu_item_filesystem_export -> exportFilesystem(filesystem)
+            R.id.menu_item_filesystem_export -> exportFilesystem(filesystem, activeSessions)
             else -> super.onContextItemSelected(item)
         }
     }
@@ -147,14 +147,8 @@ class FilesystemListFragment : Fragment() {
         return true
     }
 
-    private fun exportFilesystem(filesystem: Filesystem): Boolean {
-        if (activeSessions.isEmpty()) {
-            val externalDestination = Environment.getExternalStoragePublicDirectory("UserLAnd")
-            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, activityContext.filesDir, externalDestination)
-        } else {
-            Toast.makeText(activityContext, R.string.deactivate_sessions, Toast.LENGTH_LONG).show()
-        }
-
+    private fun exportFilesystem(filesystem: Filesystem, activeSessions: List<Session>): Boolean {
+        filesystemListViewModel.startExport(filesystem, activeSessions, activityContext.filesDir)
         return true
     }
 }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -148,7 +148,8 @@ class FilesystemListFragment : Fragment() {
     }
 
     private fun exportFilesystem(filesystem: Filesystem, activeSessions: List<Session>): Boolean {
-        filesystemListViewModel.startExport(filesystem, activeSessions, activityContext.filesDir)
+        val externalDestination = Environment.getExternalStoragePublicDirectory("UserLAnd")
+        filesystemListViewModel.startExport(filesystem, activeSessions, activityContext.filesDir, externalDestination)
         return true
     }
 }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -148,8 +148,12 @@ class FilesystemListFragment : Fragment() {
     }
 
     private fun exportFilesystem(filesystem: Filesystem): Boolean {
-        val externalDestination = Environment.getExternalStoragePublicDirectory("UserLAnd")
-        filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, activityContext.filesDir, externalDestination)
+        if (activeSessions.isEmpty()) {
+            val externalDestination = Environment.getExternalStoragePublicDirectory("UserLAnd")
+            filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, activityContext.filesDir, externalDestination)
+        } else {
+            Toast.makeText(activityContext, R.string.deactivate_sessions, Toast.LENGTH_LONG).show()
+        }
 
         return true
     }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -46,7 +46,7 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
     }
 
     private val activeSessions: LiveData<List<Session>> by lazy {
-        sessionDao.getAllSessions()
+        sessionDao.findActiveSessions()
     }
 
     fun getAllFilesystems(): LiveData<List<Filesystem>> {

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -4,7 +4,6 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
-import android.os.Environment
 import kotlinx.coroutines.* // ktlint-disable no-wildcard-imports
 import tech.ula.R
 import tech.ula.model.daos.FilesystemDao
@@ -100,9 +99,8 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
         }
     }
 
-    fun startExport(filesystem: Filesystem, activeSessions: List<Session>, filesDir: File) {
+    fun startExport(filesystem: Filesystem, activeSessions: List<Session>, filesDir: File, externalDestination: File) {
         if (activeSessions.isEmpty()) {
-            val externalDestination = Environment.getExternalStoragePublicDirectory("UserLAnd")
             compressFilesystemAndExportToStorage(filesystem, filesDir, externalDestination)
         } else {
             exportStatusLiveData.postValue(ExportFailure(R.string.deactivate_sessions))

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -52,7 +52,6 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
         return filesystems
     }
 
-
     fun getAllActiveSessions(): LiveData<List<Session>> {
         return activeSessions
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,10 @@
     <string name="error_username_invalid_characters">Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.</string>
     <string name="error_username_in_blacklist">That username is possibly reserved by Linux and cannot be used as a filesystem username.</string>
     <string name="error_filesystem_name_invalid_characters">Characters in filesystem name must be 1 to 50 characters without characters such as \"/:*\\|</string>
-
+    <string name="error_export_to_local_failed">Exporting to local directory failed</string>
+    <string name="error_export_to_external_failed">Exporting to external directory failed</string>
+    <string name="error_export_to_external_failed_no_data">Exporting to external directory failed, exported file has no data</string>
+    
     <!-- Illegal State Dialog -->
     <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>
     <string name="illegal_state_title">UserLAnd has entered an illegal state!</string>

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import tech.ula.model.daos.FilesystemDao
+import tech.ula.model.daos.SessionDao
 import tech.ula.model.entities.Filesystem
 import tech.ula.utils.FilesystemUtility
 import java.io.File
@@ -26,6 +27,8 @@ class FilesystemListViewModelTest {
     @get:Rule val tempFolder = TemporaryFolder()
 
     @Mock lateinit var mockFilesystemDao: FilesystemDao
+
+    @Mock lateinit var mockSessionDao: SessionDao
 
     @Mock lateinit var mockFilesystemUtility: FilesystemUtility
 
@@ -47,7 +50,7 @@ class FilesystemListViewModelTest {
         filesystemsLiveData = MutableLiveData()
         whenever(mockFilesystemDao.getAllFilesystems()).thenReturn(filesystemsLiveData)
 
-        filesystemListViewModel = FilesystemListViewModel(mockFilesystemDao, mockFilesystemUtility)
+        filesystemListViewModel = FilesystemListViewModel(mockFilesystemDao, mockSessionDao, mockFilesystemUtility)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/FilesystemListViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import tech.ula.R
 import tech.ula.model.daos.FilesystemDao
 import tech.ula.model.daos.SessionDao
 import tech.ula.model.entities.Filesystem
@@ -38,6 +39,8 @@ class FilesystemListViewModelTest {
 
     private lateinit var filesystemsLiveData: MutableLiveData<List<Filesystem>>
 
+    private lateinit var exportStatusLiveData: MutableLiveData<FilesystemExportStatus>
+
     private val filesystemName = "fsname"
     private val filesystemType = "fstype"
     private val rootfsString = "rootfs.tar.gz"
@@ -49,6 +52,8 @@ class FilesystemListViewModelTest {
     fun setup() {
         filesystemsLiveData = MutableLiveData()
         whenever(mockFilesystemDao.getAllFilesystems()).thenReturn(filesystemsLiveData)
+
+        exportStatusLiveData = MutableLiveData()
 
         filesystemListViewModel = FilesystemListViewModel(mockFilesystemDao, mockSessionDao, mockFilesystemUtility)
     }
@@ -106,8 +111,9 @@ class FilesystemListViewModelTest {
             filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
         }
 
+        verify(mockExportObserver).onChanged(ExportStarted)
         verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
-        verify(mockExportObserver).onChanged(ExportFailure("Exporting to local directory failed"))
+        verify(mockExportObserver).onChanged(ExportFailure(R.string.error_export_to_local_failed))
     }
 
     @Test
@@ -127,8 +133,9 @@ class FilesystemListViewModelTest {
             filesystemListViewModel.compressFilesystemAndExportToStorage(filesystem, filesDir, externalDir, this)
         }
 
+        verify(mockExportObserver).onChanged(ExportStarted)
         assertFalse(expectedLocalBackupFile.exists())
         verifyBlocking(mockFilesystemUtility) { compressFilesystem(eq(filesystem), eq(expectedLocalBackupFile), anyOrNull()) }
-        verify(mockExportObserver).onChanged(ExportFailure("Exporting to external directory failed"))
+        verify(mockExportObserver).onChanged(ExportFailure(R.string.error_export_to_external_failed))
     }
 }


### PR DESCRIPTION
**Describe the pull request**

When a user attempts to export a filesystem while a session is active, tell them to turn off any active sessions before continuing.

![ezgif com-video-to-gif(5)](https://user-images.githubusercontent.com/11577853/54379443-a87e1100-4646-11e9-87ae-9bd8a483f9fd.gif)


**Link to relevant issues**
N/A