### PR TITLE
Validate filesystem names

### DIFF
--- a/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemEditFragment.kt
@@ -279,20 +279,19 @@ class FilesystemEditFragment : Fragment() {
     private fun filesystemParametersAreCorrect(): Boolean {
         val blacklistedUsernames = activityContext.resources.getStringArray(R.array.blacklisted_usernames)
         val validator = ValidationUtility()
+        val filesystemName = filesystem.name
         val username = filesystem.defaultUsername
         val password = filesystem.defaultPassword
         val vncPassword = filesystem.defaultVncPassword
 
-        if (filesystem.name.isEmpty()) {
-            input_filesystem_name.error = getString(R.string.error_filesystem_name)
-            return false
-        }
-
+        val filesystemNameCredentials = validator.validateFilesystemName(filesystemName)
         val usernameCredentials = validator.validateUsername(username, blacklistedUsernames)
         val passwordCredentials = validator.validatePassword(password)
         val vncPasswordCredentials = validator.validateVncPassword(vncPassword)
 
         when {
+            !filesystemNameCredentials.credentialIsValid ->
+                Toast.makeText(activityContext, filesystemNameCredentials.errorMessageId, Toast.LENGTH_LONG).show()
             !usernameCredentials.credentialIsValid ->
                 Toast.makeText(activityContext, usernameCredentials.errorMessageId, Toast.LENGTH_LONG).show()
             !passwordCredentials.credentialIsValid ->

--- a/app/src/main/java/tech/ula/utils/ValidationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ValidationUtility.kt
@@ -64,16 +64,12 @@ class ValidationUtility {
     }
 
     private fun validateFilesystemNameCharacters(filesystemName: String): Boolean {
-        val usernameRegex = "([a-zA-Z0-9!@#$%^&()_+=,.?<>]{0,50})"
+        val filesystemNameRegex = "([a-zA-Z0-9!@#$%^&()_+=,.?<>]{0,50})"
 
-        val compiledRegex = Pattern.compile(usernameRegex)
+        val compiledRegex = Pattern.compile(filesystemNameRegex)
         val matcher = compiledRegex.matcher(filesystemName)
         val hasValidCharacters = matcher.matches()
-
-        if (hasValidCharacters) {
-            return true
-        }
-        return false
+        return hasValidCharacters
     }
 
     private fun validateUsernameCharacters(username: String): Boolean {
@@ -82,11 +78,7 @@ class ValidationUtility {
         val compiledRegex = Pattern.compile(usernameRegex)
         val matcher = compiledRegex.matcher(username)
         val hasValidCharacters = matcher.matches()
-
-        if (hasValidCharacters) {
-            return true
-        }
-        return false
+        return hasValidCharacters
     }
 
     private fun validatePasswordCharacters(password: String): Boolean {
@@ -97,8 +89,8 @@ class ValidationUtility {
 
         pattern = Pattern.compile(passwordRegex)
         matcher = pattern.matcher(password)
-
-        return matcher.matches()
+        val hasValidCharacters = matcher.matches()
+        return hasValidCharacters
     }
 }
 

--- a/app/src/main/java/tech/ula/utils/ValidationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ValidationUtility.kt
@@ -6,6 +6,21 @@ import java.util.regex.Pattern
 
 class ValidationUtility {
 
+    fun validateFilesystemName(filesystemName: String): CredentialValidationStatus {
+        return when {
+            filesystemName.isEmpty() ->
+                CredentialValidationStatus(false, R.string.error_filesystem_name)
+
+            !validateFilesystemNameCharacters(filesystemName) ->
+                CredentialValidationStatus(false, R.string.error_filesystem_name_invalid_characters)
+
+            filesystemName == "." || filesystemName == ".." ->
+                CredentialValidationStatus(false, R.string.error_filesystem_name_invalid_characters)
+
+            else -> CredentialValidationStatus(true)
+        }
+    }
+
     fun validateUsername(username: String, blacklistUsernames: Array<String>): CredentialValidationStatus {
         return when {
             username.isEmpty() ->
@@ -46,6 +61,19 @@ class ValidationUtility {
 
             else -> CredentialValidationStatus(true)
         }
+    }
+
+    private fun validateFilesystemNameCharacters(filesystemName: String): Boolean {
+        val usernameRegex = "([a-zA-Z0-9!@#$%^&()_+=,.?<>]{0,50})"
+
+        val compiledRegex = Pattern.compile(usernameRegex)
+        val matcher = compiledRegex.matcher(filesystemName)
+        val hasValidCharacters = matcher.matches()
+
+        if (hasValidCharacters) {
+            return true
+        }
+        return false
     }
 
     private fun validateUsernameCharacters(username: String): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="error_vnc_password_invalid">VNC Password has invalid characters</string>
     <string name="error_username_invalid_characters">Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.</string>
     <string name="error_username_in_blacklist">That username is possibly reserved by Linux and cannot be used as a filesystem username.</string>
+    <string name="error_filesystem_name_invalid_characters">Characters in filesystem name must be 1 to 50 characters without characters such as "/:*\|</string>
 
     <!-- Illegal State Dialog -->
     <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="error_vnc_password_invalid">VNC Password has invalid characters</string>
     <string name="error_username_invalid_characters">Characters in username must be 1 to 30 characters with lowercase letters and/or numbers.</string>
     <string name="error_username_in_blacklist">That username is possibly reserved by Linux and cannot be used as a filesystem username.</string>
-    <string name="error_filesystem_name_invalid_characters">Characters in filesystem name must be 1 to 50 characters without characters such as "/:*\|</string>
+    <string name="error_filesystem_name_invalid_characters">Characters in filesystem name must be 1 to 50 characters without characters such as \"/:*\\|</string>
 
     <!-- Illegal State Dialog -->
     <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -43,6 +43,14 @@ class ValidationUtilityTest {
     }
 
     @Test
+    fun `Validate fails appropriately if filesystem name is just two periods`() {
+        val filesystemName = ".."
+        credential = validationUtility.validateFilesystemName(filesystemName)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessageId, R.string.error_filesystem_name_invalid_characters)
+    }
+
+    @Test
     fun `Validate fails appropriately if filesystem name has invalid characters such as forward slashes`() {
         val filesystemName = "filename/"
         credential = validationUtility.validateFilesystemName(filesystemName)

--- a/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ValidationUtilityTest.kt
@@ -27,6 +27,38 @@ class ValidationUtilityTest {
     }
 
     @Test
+    fun `Validate fails appropriately if filesystem name is empty`() {
+        val filesystemName = ""
+        credential = validationUtility.validateFilesystemName(filesystemName)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessageId, R.string.error_filesystem_name)
+    }
+
+    @Test
+    fun `Validate fails appropriately if filesystem name is just a period`() {
+        val filesystemName = "."
+        credential = validationUtility.validateFilesystemName(filesystemName)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessageId, R.string.error_filesystem_name_invalid_characters)
+    }
+
+    @Test
+    fun `Validate fails appropriately if filesystem name has invalid characters such as forward slashes`() {
+        val filesystemName = "filename/"
+        credential = validationUtility.validateFilesystemName(filesystemName)
+        assertFalse(credential.credentialIsValid)
+        assertEquals(credential.errorMessageId, R.string.error_filesystem_name_invalid_characters)
+    }
+
+    @Test
+    fun `Validate succeeds if filesystem name is just letters and underscores`() {
+        val filesystemName = "filesystem_name"
+        credential = validationUtility.validateFilesystemName(filesystemName)
+        assertTrue(credential.credentialIsValid)
+        assertEquals(credential.errorMessageId, R.string.general_error_title)
+    }
+
+    @Test
     fun `Validate fails appropriately if username is empty`() {
         val username = ""
         credential = validationUtility.validateUsername(username, blacklistUsernames)


### PR DESCRIPTION
**Describe the pull request**

Validate filesystem names during creation to avoid bad characters, including FAT special characters.  
Used this as a reference on what characters to filter out:
https://stackoverflow.com/questions/4814040/allowed-characters-in-filename

![Screen Shot 2019-03-14 at 11 20 34 AM](https://user-images.githubusercontent.com/11577853/54381617-76bb7900-464b-11e9-9c2f-75ea6233b60b.png)


![Screen Shot 2019-03-14 at 11 20 21 AM](https://user-images.githubusercontent.com/11577853/54381626-79b66980-464b-11e9-8e84-c96044a47d4d.png)

**Link to relevant issues**
N/A