### PR TITLE
Downloads fix

### DIFF
--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -66,7 +66,7 @@ class AssetRepository(
 
     fun assetsArePresentInSupportDirectories(assets: List<Asset>): Boolean {
         for (asset in assets) {
-            if (asset.name.contains("rootfs.tar.gz")) continue  
+            if (asset.name.contains("rootfs.tar.gz")) continue
             val assetFile = File("$applicationFilesDirPath/${asset.pathName}")
             if (!assetFile.exists()) return false
         }

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -66,6 +66,7 @@ class AssetRepository(
 
     fun assetsArePresentInSupportDirectories(assets: List<Asset>): Boolean {
         for (asset in assets) {
+            if (asset.name.contains("rootfs.tar.gz")) continue  
             val assetFile = File("$applicationFilesDirPath/${asset.pathName}")
             if (!assetFile.exists()) return false
         }

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -56,7 +56,8 @@ class AssetRepository(
     }
 
     fun getDistributionAssetsForExistingFilesystem(filesystem: Filesystem): List<Asset> {
-        return assetPreferences.getCachedAssetList(filesystem.distributionType)
+        val assets = assetPreferences.getCachedAssetList(filesystem.distributionType)
+        return assets.filter { !it.name.contains("rootfs") }
     }
 
     fun getLatestDistributionVersion(distributionType: String): String {

--- a/app/src/main/java/tech/ula/utils/DownloadUtility.kt
+++ b/app/src/main/java/tech/ula/utils/DownloadUtility.kt
@@ -126,6 +126,15 @@ class DownloadUtility(
         val target = File("${destinationDirectory.absolutePath}/$filename")
 
         destinationDirectory.mkdirs()
+
+        // Clear old rootfs parts if they exist
+        val directoryFiles = destinationDirectory.listFiles()
+        directoryFiles?.let {
+            for (file in directoryFiles) {
+                if (file.name.contains("rootfs.tar.gz.part")) file.delete()
+            }
+        }
+
         rootFsFile.copyTo(target, overwrite = true)
         rootFsFile.delete()
         assetPreferences.setLatestDownloadFilesystemVersion(repo, version)

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -294,8 +294,8 @@ class AssetRepositoryTest {
     }
 
     @Test
-    fun `assetsArePresentInSupportDirectories correctly reports existence`() {
-        val assetList = listOf(supportAsset, distAsset)
+    fun `assetsArePresentInSupportDirectories correctly reports existence, skipping rootfs files`() {
+        val assetList = listOf(supportAsset, distAsset, Asset("rootfs.tar.gz", distAsset.type))
 
         val supportDir = File("$applicationFilesDirPath/$supportRepo")
         val supportAssetFile = File("${supportDir.absolutePath}/${supportAsset.name}")

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -268,15 +268,17 @@ class AssetRepositoryTest {
     }
 
     @Test
-    fun `getDistributionAssetsForExistingFilesystem propagates to AssetPreferences`() {
-        val assetList = listOf(distAsset)
+    fun `getDistributionAssetsForExistingFilesystem propagates to AssetPreferences, and removes rootfs from list`() {
+        val rootFsAsset = Asset("rootfs.tar.gz", distAsset.type)
+        val assetList = listOf(distAsset, rootFsAsset)
         whenever(mockAssetPreferences.getCachedAssetList(filesystem.distributionType))
                 .thenReturn(assetList)
 
         val result = assetRepository.getDistributionAssetsForExistingFilesystem(filesystem)
 
+        val expectedResult = assetList.minus(rootFsAsset)
         verify(mockAssetPreferences).getCachedAssetList(filesystem.distributionType)
-        assertEquals(assetList, result)
+        assertEquals(expectedResult, result)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/DownloadUtilityTest.kt
@@ -280,6 +280,31 @@ class DownloadUtilityTest {
     }
 
     @Test
+    fun `prepareDownloadsForUse deletes old rootfs part files`() {
+        val downloadedRootfs = File("${downloadDirectory.absolutePath}/$userlandDownloadPrefix${downloadMetadata1.downloadTitle}")
+        downloadedRootfs.createNewFile()
+
+        val destinationDirectory = File("${mockFilesDir.absolutePath}/$type1")
+        val destinationFile = File("${destinationDirectory.absolutePath}/$rootfsName")
+        val rootfsPartFile1 = File("${destinationDirectory.absolutePath}/rootfs.tar.gz.part00")
+        val rootFsPartFile2 = File("${destinationDirectory.absolutePath}/rootfs.tar.gz.part01")
+
+        destinationDirectory.mkdirs()
+        rootfsPartFile1.createNewFile()
+        rootFsPartFile2.createNewFile()
+
+        runBlocking { downloadUtility.prepareDownloadsForUse(mockArchiveFactoryWrapper) }
+
+        assertFalse(downloadedRootfs.exists())
+
+        assertTrue(destinationDirectory.exists())
+        assertTrue(destinationFile.exists())
+        assertFalse(rootfsPartFile1.exists())
+        assertFalse(rootFsPartFile2.exists())
+        verify(assetPreferences).setLatestDownloadFilesystemVersion(type1, version)
+    }
+
+    @Test
     fun `prepareDownloadsForUse overwrites stale rootfs files`() {
         val expectedText = "expected"
         val downloadedRootfs = File("${downloadDirectory.absolutePath}/$userlandDownloadPrefix${downloadMetadata1.downloadTitle}")


### PR DESCRIPTION
**Describe the pull request**

The session FSM was reporting assets missing during upgrades from v2.4 to the new downloads flow when using an existing filesystem. This PR matches old behavior of just ignoring rootfs files during this check, since they won't be needed until they are extracted for a new filesystem. It also ignores rootfs files when checking whether assets are present in support directories while generating downloads, as it was currently forcing a second download of `assets.tar.gz` if the new assets had already been downloaded but the new filesystem had not been.

Old rootfs part files will also be deleted the first time a new filesystem of that type is downloaded.

**Link to relevant issues**
N/A