### PR TITLE
Fix importing for new download flow, and allow importing apps fs to work.

### DIFF
--- a/app/src/main/java/tech/ula/model/entities/Filesystem.kt
+++ b/app/src/main/java/tech/ula/model/entities/Filesystem.kt
@@ -16,13 +16,13 @@ data class Filesystem(
     var defaultUsername: String = "",
     var defaultPassword: String = "",
     var defaultVncPassword: String = "",
-    val isAppsFilesystem: Boolean = false,
+    var isAppsFilesystem: Boolean = false,
     var versionCodeUsed: String = "v0.0.0",
     var isCreatedFromBackup: Boolean = false
 ) : Parcelable {
     override fun toString(): String {
         return "Filesystem(id=$id, name=$name, distributionType=$distributionType, archType=" +
                 "$archType, isAppsFilesystem=$isAppsFilesystem, versionCodeUsed=$versionCodeUsed, " +
-                "isCreatedFromBackup$isCreatedFromBackup"
+                "isCreatedFromBackup=$isCreatedFromBackup"
     }
 }

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -241,11 +241,12 @@ class SessionStartupFsm(
             }
 
             try {
-                filesystemUtility.copyAssetsToFilesystem("${filesystem.id}", filesystem.distributionType)
+                filesystemUtility.copyAssetsToFilesystem(filesystem)
                 filesystem.versionCodeUsed = lastDownloadedAssetVersion
                 filesystemDao.updateFilesystem(filesystem)
             } catch (err: Exception) {
                 state.postValue(FilesystemAssetCopyFailed)
+                return@withContext
             }
 
             if (filesystemUtility.hasFilesystemBeenSuccessfullyExtracted(filesystemDirectoryName)) {

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemEditViewModel.kt
@@ -55,6 +55,7 @@ class FilesystemEditViewModel(private val ulaDatabase: UlaDatabase) : ViewModel(
                 return@withContext
             }
 
+            if (filesystem.name.toLowerCase() == "apps") filesystem.isAppsFilesystem = true
             filesystem.isCreatedFromBackup = true
             val id = ulaDatabase.filesystemDao().insertFilesystem(filesystem)
 

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -325,12 +325,12 @@ class SessionStartupFsmTest {
         sessionFsm.setState(AssetListsRetrievalSucceeded(assetLists))
         sessionFsm.getState().observeForever(mockStateObserver)
 
-        val filesysteNeedsExtraction = false
+        val filesystemNeedsExtraction = false
         whenever(mockFilesystemUtility.hasFilesystemBeenSuccessfullyExtracted("${filesystem.id}"))
                 .thenReturn(true)
 
         runBlocking {
-            whenever(mockAssetRepository.generateDownloadRequirements(filesystem, assetLists, filesysteNeedsExtraction))
+            whenever(mockAssetRepository.generateDownloadRequirements(filesystem, assetLists, filesystemNeedsExtraction))
                     .thenReturn(listOf())
 
             sessionFsm.submitEvent(GenerateDownloads(filesystem, assetLists), this)
@@ -338,7 +338,7 @@ class SessionStartupFsmTest {
 
         verify(mockStateObserver).onChanged(GeneratingDownloadRequirements)
         verify(mockStateObserver).onChanged(NoDownloadsRequired)
-        verifyBlocking(mockAssetRepository) { generateDownloadRequirements(filesystem, assetLists, filesysteNeedsExtraction) }
+        verifyBlocking(mockAssetRepository) { generateDownloadRequirements(filesystem, assetLists, filesystemNeedsExtraction) }
     }
 
     @Test
@@ -656,7 +656,7 @@ class SessionStartupFsmTest {
 
         val updatedFilesystem = filesystem
         updatedFilesystem.versionCodeUsed = highVersionCode
-        verify(mockFilesystemUtility).copyAssetsToFilesystem("${filesystem.id}", filesystem.distributionType)
+        verify(mockFilesystemUtility).copyAssetsToFilesystem(filesystem)
         verify(mockFilesystemDao).updateFilesystem(updatedFilesystem)
         verify(mockFilesystemUtility, never()).removeRootfsFilesFromFilesystem("${filesystem.id}")
         verify(mockStateObserver).onChanged(VerifyingFilesystemAssets)
@@ -685,7 +685,7 @@ class SessionStartupFsmTest {
 
         val updatedFilesystem = filesystem
         updatedFilesystem.versionCodeUsed = highVersionCode
-        verify(mockFilesystemUtility).copyAssetsToFilesystem("${filesystem.id}", filesystem.distributionType)
+        verify(mockFilesystemUtility).copyAssetsToFilesystem(filesystem)
         verify(mockFilesystemDao).updateFilesystem(updatedFilesystem)
         verify(mockFilesystemUtility).removeRootfsFilesFromFilesystem("${filesystem.id}")
         verify(mockStateObserver).onChanged(VerifyingFilesystemAssets)
@@ -708,7 +708,7 @@ class SessionStartupFsmTest {
 
         whenever(mockAssetRepository.assetsArePresentInSupportDirectories(assetList))
                 .thenReturn(true)
-        whenever(mockFilesystemUtility.copyAssetsToFilesystem("${filesystem.id}", filesystem.distributionType))
+        whenever(mockFilesystemUtility.copyAssetsToFilesystem(filesystem))
                 .thenThrow(Exception::class.java)
 
         runBlocking { sessionFsm.submitEvent(VerifyFilesystemAssets(filesystem), this) }


### PR DESCRIPTION
**Describe the pull request**

Fixes importing filesystems by not overwriting backups when copying assets to new filesystems. Also will allow imported backups to be used as apps filesystems if they are named "apps".

**Link to relevant issues**
N/A