### PR TITLE
Improve logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 55
-        versionName "2.5.1"
+        versionCode 56
+        versionName "2.5.2"
         
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/release/output.json
+++ b/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":55,"versionName":"2.5.1","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":56,"versionName":"2.5.2","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -198,7 +198,7 @@ class ServerService : Service() {
     private fun cleanUpFilesystem(filesystemId: Long) {
         // TODO This could potentially be handled by the main activity (viewmodel) now
         if (filesystemId == (-1).toLong()) {
-            throw Exception("Did not receive filesystemId")
+            AcraWrapper().logAndThrow(IllegalStateException("Did not receive filesystemId"))
         }
 
         activeSessions.values.filter { it.filesystemId == filesystemId }

--- a/app/src/main/java/tech/ula/model/remote/GithubApiClient.kt
+++ b/app/src/main/java/tech/ula/model/remote/GithubApiClient.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import tech.ula.utils.AcraWrapper
 import tech.ula.utils.BuildWrapper
 import java.io.IOException
 
@@ -18,7 +19,8 @@ class UrlProvider {
 
 class GithubApiClient(
     private val buildWrapper: BuildWrapper = BuildWrapper(),
-    private val urlProvider: UrlProvider = UrlProvider()
+    private val urlProvider: UrlProvider = UrlProvider(),
+    private val acraWrapper: AcraWrapper = AcraWrapper()
 ) {
     private val client = OkHttpClient()
     private val latestResults: HashMap<String, ReleasesResponse?> = hashMapOf()
@@ -66,7 +68,7 @@ class GithubApiClient(
                 .url(url)
                 .build()
         val response = client.newCall(request).execute()
-        if (!response.isSuccessful) throw IOException("Unexpected code: $response")
+        if (!response.isSuccessful) acraWrapper.logAndThrow(IOException("Unexpected code: $response"))
 
         val result = adapter.fromJson(response.body()!!.source())!!
         latestResults[repo] = result

--- a/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
+++ b/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
@@ -11,7 +11,6 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStreamReader
 import java.net.URL
-import javax.net.ssl.SSLHandshakeException
 
 interface RemoteAppsSource {
     fun getHostname(): String
@@ -26,9 +25,9 @@ interface RemoteAppsSource {
 }
 
 class GithubAppsFetcher(
-        private val applicationFilesDir: String,
-        private val connectionUtility: ConnectionUtility = ConnectionUtility(),
-        private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val applicationFilesDir: String,
+    private val connectionUtility: ConnectionUtility = ConnectionUtility(),
+    private val acraWrapper: AcraWrapper = AcraWrapper()
 ) : RemoteAppsSource {
 
     // Allows destructing of the list of application elements

--- a/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
+++ b/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
@@ -61,7 +61,7 @@ class GithubAppsFetcher(
             appsList.toList()
         } catch (err: Exception) {
             acraWrapper.logAndThrow(IOException("Error getting apps list"))
-            listOf() // Never reaches here
+            error("Not reached, ignore return type")
         }
     }
 

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -3,6 +3,7 @@ package tech.ula.model.repositories
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.remote.GithubApiClient
+import tech.ula.utils.AcraWrapper
 import tech.ula.utils.AssetPreferences
 import tech.ula.utils.ConnectionUtility
 import java.io.BufferedReader
@@ -22,7 +23,8 @@ class AssetRepository(
     private val applicationFilesDirPath: String,
     private val assetPreferences: AssetPreferences,
     private val githubApiClient: GithubApiClient = GithubApiClient(),
-    private val connectionUtility: ConnectionUtility = ConnectionUtility()
+    private val connectionUtility: ConnectionUtility = ConnectionUtility(),
+    private val acraWrapper: AcraWrapper = AcraWrapper()
 ) {
 
     @Throws(IllegalStateException::class)
@@ -35,7 +37,7 @@ class AssetRepository(
         for (entry in assetLists) {
             val (repo, list) = entry
             // Empty lists should not have propagated this deeply.
-            if (list.isEmpty()) throw IllegalStateException()
+            if (list.isEmpty()) acraWrapper.logAndThrow(IllegalStateException())
             if (assetsArePresentInSupportDirectories(list) && lastDownloadedVersionIsUpToDate(repo))
                 continue
             val filename = "assets.tar.gz"

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -236,7 +236,7 @@ class BuildWrapper {
                 }
         return if (supportedABIS.size == 1 && supportedABIS[0] == "") {
             AcraWrapper().logAndThrow(IllegalStateException("No supported ABI!"))
-            "" // never reached
+            error("never reached, ignore return type")
         } else {
             supportedABIS[0]
         }

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -388,6 +388,14 @@ class AcraWrapper {
     fun putCustomString(key: String, value: String) {
         ACRA.getErrorReporter().putCustomData(key, value)
     }
+    @Throws(Exception::class)
+    fun logAndThrow(err: Exception) {
+        val key = "Exception thrown"
+        val topOfStackTrace = err.stackTrace.first()
+        val value = "${topOfStackTrace.fileName}: ${topOfStackTrace.lineNumber}"
+        ACRA.getErrorReporter().putCustomData(key, value)
+        throw err
+    }
 }
 
 class DeviceDimensions {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -234,10 +234,11 @@ class BuildWrapper {
                 .filter {
                     isSupported(it)
                 }
-        if (supportedABIS.size == 1 && supportedABIS[0] == "") {
-            throw Exception("No supported ABI!")
+        return if (supportedABIS.size == 1 && supportedABIS[0] == "") {
+            AcraWrapper().logAndThrow(IllegalStateException("No supported ABI!"))
+            "" // never reached
         } else {
-            return supportedABIS[0]
+            supportedABIS[0]
         }
     }
 
@@ -290,15 +291,6 @@ class DownloadManagerWrapper(private val downloadManager: DownloadManager) {
 
     private fun generateCursor(query: DownloadManager.Query): Cursor {
         return downloadManager.query(query)
-    }
-
-    fun getDownloadTitle(id: Long): String {
-        val query = generateQuery(id)
-        val cursor = generateCursor(query)
-        if (cursor.moveToFirst()) {
-            return cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_TITLE))
-        }
-        return ""
     }
 
     fun downloadHasSucceeded(id: Long): Boolean {
@@ -374,25 +366,15 @@ class LocalFileLocator(private val applicationFilesDir: String, private val reso
     }
 }
 
-class TimeUtility {
-    fun getCurrentTimeSeconds(): Long {
-        return currentTimeSeconds()
-    }
-
-    fun getCurrentTimeMillis(): Long {
-        return System.currentTimeMillis()
-    }
-}
-
 class AcraWrapper {
     fun putCustomString(key: String, value: String) {
         ACRA.getErrorReporter().putCustomData(key, value)
     }
     @Throws(Exception::class)
     fun logAndThrow(err: Exception) {
-        val key = "Exception thrown"
         val topOfStackTrace = err.stackTrace.first()
-        val value = "${topOfStackTrace.fileName}: ${topOfStackTrace.lineNumber}"
+        val key = "Exception: ${topOfStackTrace.fileName}"
+        val value = "${topOfStackTrace.lineNumber}"
         ACRA.getErrorReporter().putCustomData(key, value)
         throw err
     }

--- a/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
+++ b/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
@@ -1,5 +1,6 @@
 package tech.ula.model.remote
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -15,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import tech.ula.utils.AcraWrapper
 import tech.ula.utils.BuildWrapper
 import java.io.IOException
 
@@ -27,9 +29,11 @@ class GithubApiClientTest {
 
     @Mock lateinit var mockUrlProvider: UrlProvider
 
+    @Mock lateinit var mockAcraWrapper: AcraWrapper
+
     private val moshi = Moshi.Builder().build()
 
-    lateinit var githubApiClient: GithubApiClient
+    private lateinit var githubApiClient: GithubApiClient
 
     private val testRepo = "repo"
     private val testReleaseToUse = "latest"
@@ -75,7 +79,7 @@ class GithubApiClientTest {
     fun setup() {
         whenever(mockBuildWrapper.getArchType()).thenReturn(testArch)
 
-        githubApiClient = GithubApiClient(buildWrapper = mockBuildWrapper, urlProvider = mockUrlProvider)
+        githubApiClient = GithubApiClient(mockBuildWrapper, mockUrlProvider, mockAcraWrapper)
     }
 
     @After
@@ -83,7 +87,7 @@ class GithubApiClientTest {
         server.shutdown()
     }
 
-    fun stubBaseUrl() {
+    private fun stubBaseUrl() {
         val url = server.url("/")
         whenever(mockUrlProvider.getBaseUrl()).thenReturn("${url.url()}")
     }
@@ -136,8 +140,12 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
+        whenever(mockAcraWrapper.logAndThrow(any()))
+                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getAssetsListDownloadUrl(testRepo) }
+
+        verify(mockAcraWrapper.logAndThrow(IOException()))
     }
 
     @Test
@@ -177,8 +185,12 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
+        whenever(mockAcraWrapper.logAndThrow(any()))
+                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getLatestReleaseVersion(testRepo) }
+
+        verify(mockAcraWrapper.logAndThrow(IOException()))
     }
 
     @Test
@@ -218,8 +230,12 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
+        whenever(mockAcraWrapper.logAndThrow(any()))
+                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getAssetEndpoint(testAssetType, testRepo) }
+
+        verify(mockAcraWrapper).logAndThrow(IOException())
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
@@ -21,6 +21,7 @@ import tech.ula.model.entities.Filesystem
 import tech.ula.model.entities.Session
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
+import java.io.IOException
 
 @RunWith(MockitoJUnitRunner::class)
 class AppsStartupFsmTest {
@@ -341,7 +342,7 @@ class AppsStartupFsmTest {
         appsFsm.getState().observeForever(mockStateObserver)
 
         whenever(mockFilesystemUtility.moveAppScriptToRequiredLocation(app.name, appsFilesystem))
-                .thenThrow(Exception())
+                .thenThrow(IOException())
 
         runBlocking { appsFsm.submitEvent(CopyAppScriptToFilesystem(app, appsFilesystem), this) }
 

--- a/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
@@ -23,6 +23,8 @@ class AssetFileClearerTest {
 
     @Mock lateinit var busyboxExecutor: BusyboxExecutor
 
+    @Mock lateinit var mockAcraWrapper: AcraWrapper
+
     lateinit var filesDir: File
     lateinit var supportDir: File
     lateinit var debianDir: File
@@ -50,7 +52,7 @@ class AssetFileClearerTest {
     fun setup() {
         createTestFiles()
 
-        assetFileClearer = AssetFileClearer(filesDir, assetDirectoryNames, busyboxExecutor)
+        assetFileClearer = AssetFileClearer(filesDir, assetDirectoryNames, busyboxExecutor, mockAcraWrapper)
     }
 
     fun createTestFiles() {
@@ -77,8 +79,12 @@ class AssetFileClearerTest {
     @Test(expected = FileNotFoundException::class)
     fun `Throws FileNotFoundException if files directory does not exist`() {
         filesDir.deleteRecursively()
+        whenever(mockAcraWrapper.logAndThrow(any()))
+                .thenThrow(FileNotFoundException())
 
         runBlocking { assetFileClearer.clearAllSupportAssets() }
+
+        verify(mockAcraWrapper.logAndThrow(FileNotFoundException()))
     }
 
     @Test


### PR DESCRIPTION
**Describe the pull request**

Now, anytime an exception would normally be thrown, we also log information about it using ACRA. This is mostly to get more fine-tuned information in the cases where exceptions eventually resulted in the catch-all IllegalStateException that is thrown after a failure dialog is shown to the user. This should help fine-tune some crash reports we are seeing.

**Link to relevant issues**
N/A