### PR TITLE
Change default extra-keys bar in terminal

### DIFF
--- a/termux-app/terminal-term/src/main/java/com/termux/app/ExtraKeysView.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/ExtraKeysView.java
@@ -36,6 +36,12 @@ public final class ExtraKeysView extends GridLayout {
     private static final int INTERESTING_COLOR = 0xFF80DEEA;
     private static final int BUTTON_PRESSED_COLOR = 0x7FFFFFFF;
 
+    /**
+     *  Variables used when swiping the extra keys row. Prevent a KEY_PRESS_DOWN when swiping
+     */
+    private float actionDownPosition;
+    private static final int MIN_SWIPE_DISTANCE = 50;
+
     public ExtraKeysView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
@@ -359,6 +365,7 @@ public final class ExtraKeysView extends GridLayout {
                     final View root = getRootView();
                     switch (event.getAction()) {
                         case MotionEvent.ACTION_DOWN:
+                            actionDownPosition = event.getX();
                             longPressCount = 0;
                             v.setBackgroundColor(BUTTON_PRESSED_COLOR);
                             if (Arrays.asList("UP", "DOWN", "LEFT", "RIGHT").contains(buttonText)) {
@@ -393,6 +400,12 @@ public final class ExtraKeysView extends GridLayout {
                                 scheduledExecutor.shutdownNow();
                                 scheduledExecutor = null;
                             }
+
+                            float actionUpLocation = event.getX();
+                            float deltaX = actionUpLocation - actionDownPosition;
+                            if (Math.abs(deltaX) > MIN_SWIPE_DISTANCE)
+                                return true;
+
                             if (longPressCount == 0) {
                                 if (popupWindow != null && Arrays.asList("/", "-").contains(buttonText)) {
                                     popupWindow.setContentView(null);

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -221,7 +221,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         viewPager.setAdapter(new PagerAdapter() {
             @Override
             public int getCount() {
-                return 2;
+                return 3;
             }
 
             @Override
@@ -237,6 +237,9 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
                     mExtraKeysView.reload(mSettings.mExtraKeys, ExtraKeysView.defaultCharDisplay);
+                } else if (position == 1) {
+                    layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
+                    mExtraKeysView.reload(mSettings.mExtraKeys2, ExtraKeysView.defaultCharDisplay);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxActivity.java
@@ -221,7 +221,7 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
         viewPager.setAdapter(new PagerAdapter() {
             @Override
             public int getCount() {
-                return 3;
+                return 2;
             }
 
             @Override
@@ -237,9 +237,6 @@ public final class TermuxActivity extends Activity implements ServiceConnection 
                 if (position == 0) {
                     layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
                     mExtraKeysView.reload(mSettings.mExtraKeys, ExtraKeysView.defaultCharDisplay);
-                } else if (position == 1) {
-                    layout = mExtraKeysView = (ExtraKeysView) inflater.inflate(R.layout.extra_keys_main, collection, false);
-                    mExtraKeysView.reload(mSettings.mExtraKeys2, ExtraKeysView.defaultCharDisplay);
                 } else {
                     layout = inflater.inflate(R.layout.extra_keys_right, collection, false);
                     final EditText editText = layout.findViewById(R.id.text_input);

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
@@ -115,7 +115,6 @@ final class TermuxPreferences {
     }
     
     public String[][] mExtraKeys;
-    public String[][] mExtraKeys2;
 
     public void reloadFromProperties(Context context) {
         File propsFile = new File(TermuxService.HOME_PATH + "/.termux/termux.properties");
@@ -147,9 +146,10 @@ final class TermuxPreferences {
                 break;
         }
 
+
         try {
-            JSONArray arr = new JSONArray(props.getProperty("extra-keys", "[['ESC', 'TAB', 'CTRL', 'ALT', '-', 'DOWN', 'UP']]"));
-            JSONArray secondArr = new JSONArray(props.getProperty("extra-keys", "[['TAB', 'HOME', 'END', 'PGUP', 'PGDN', 'LEFT', 'RIGHT']]"));
+            String keys = "[['ESC', '/', '-', 'HOME', 'UP', 'END', 'PGUP'], ['TAB', 'CTRL', 'ALT', 'LEFT', 'DOWN', 'RIGHT', 'PGDN']]";
+            JSONArray arr = new JSONArray(props.getProperty("extra-keys", keys));
 
             mExtraKeys = new String[arr.length()][];
             for (int i = 0; i < arr.length(); i++) {
@@ -160,20 +160,10 @@ final class TermuxPreferences {
                 }
             }
 
-            mExtraKeys2 = new String[secondArr.length()][];
-            for (int i = 0; i < secondArr.length(); i++) {
-                JSONArray line = secondArr.getJSONArray(i);
-                mExtraKeys2[i] = new String[line.length()];
-                for (int j = 0; j < line.length(); j++) {
-                    mExtraKeys2[i][j] = line.getString(j);
-                }
-            }
-
         } catch (JSONException e) {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
             mExtraKeys = new String[0][];
-            mExtraKeys2 = new String[0][];
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
@@ -115,6 +115,7 @@ final class TermuxPreferences {
     }
     
     public String[][] mExtraKeys;
+    public String[][] mExtraKeys2;
 
     public void reloadFromProperties(Context context) {
         File propsFile = new File(TermuxService.HOME_PATH + "/.termux/termux.properties");
@@ -148,6 +149,7 @@ final class TermuxPreferences {
 
         try {
             JSONArray arr = new JSONArray(props.getProperty("extra-keys", "[['ESC', 'TAB', 'CTRL', 'ALT', '-', 'DOWN', 'UP']]"));
+            JSONArray secondArr = new JSONArray(props.getProperty("extra-keys", "[['TAB', 'HOME', 'END', 'PGUP', 'PGDN', 'LEFT', 'RIGHT']]"));
 
             mExtraKeys = new String[arr.length()][];
             for (int i = 0; i < arr.length(); i++) {
@@ -157,10 +159,21 @@ final class TermuxPreferences {
                     mExtraKeys[i][j] = line.getString(j);
                 }
             }
+
+            mExtraKeys2 = new String[secondArr.length()][];
+            for (int i = 0; i < secondArr.length(); i++) {
+                JSONArray line = secondArr.getJSONArray(i);
+                mExtraKeys2[i] = new String[line.length()];
+                for (int j = 0; j < line.length(); j++) {
+                    mExtraKeys2[i][j] = line.getString(j);
+                }
+            }
+
         } catch (JSONException e) {
             Toast.makeText(context, "Could not load the extra-keys property from the config: " + e.toString(), Toast.LENGTH_LONG).show();
             Log.e("termux", "Error loading props", e);
             mExtraKeys = new String[0][];
+            mExtraKeys2 = new String[0][];
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));

--- a/termux-app/terminal-term/src/main/res/layout/drawer_layout.xml
+++ b/termux-app/terminal-term/src/main/res/layout/drawer_layout.xml
@@ -72,7 +72,7 @@
         android:id="@+id/viewpager"
         android:visibility="gone"
         android:layout_width="match_parent"
-        android:layout_height="75dp"
+        android:layout_height="37.5dp"
         android:background="@android:drawable/screen_background_dark_transparent"
         android:layout_alignParentBottom="true" />
 </RelativeLayout>


### PR DESCRIPTION
**Describe the pull request**

For the UserLAnd terminal, this PR adds a second row in the extra-keys bar (which sits above the keyboard) that includes the following keys: TAB, HOME, END, PGUP, PGDOWN, LEFT and RIGHT.

It is important to note that for any user that has configured their own extra-keys layout, their layout will still be in effect. 👍 

I've changed my extra-keys layout according to this comment here:
https://github.com/CypherpunkArmory/UserLAnd/issues/617#issuecomment-477759175

Previously there was an issue when adding a second row.  If a swipe action occurred (for example to swipe left to go from the first to the second row) the initial touch down action would count as an key press event.  This PR will fix this issue.  When swiping, there will be no key press events submitted.

Also this PR reduces the height of the extra-keys bar by half to take up less space.

![](https://media.giphy.com/media/3s4khlFewmuXkNuECa/giphy.gif)

**Link to relevant issues**
#617 
