### PR TITLE
Explicitly handle failed host resolution and improve logging flow.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -451,6 +451,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             is ErrorFetchingAssetLists -> {
                 getString(R.string.illegal_state_error_fetching_asset_lists)
             }
+            is ErrorGeneratingDownloads -> {
+                getString(state.errorId)
+            }
             is DownloadsDidNotCompleteSuccessfully -> {
                 getString(R.string.illegal_state_downloads_did_not_complete_successfully, state.reason)
             }

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -198,7 +198,9 @@ class ServerService : Service() {
     private fun cleanUpFilesystem(filesystemId: Long) {
         // TODO This could potentially be handled by the main activity (viewmodel) now
         if (filesystemId == (-1).toLong()) {
-            AcraWrapper().logAndThrow(IllegalStateException("Did not receive filesystemId"))
+            val exception = IllegalStateException("Did not receive filesystemId")
+            AcraWrapper().logException(exception)
+            throw exception
         }
 
         activeSessions.values.filter { it.filesystemId == filesystemId }

--- a/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
+++ b/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
@@ -60,8 +60,9 @@ class GithubAppsFetcher(
             reader.close()
             appsList.toList()
         } catch (err: Exception) {
-            acraWrapper.logAndThrow(IOException("Error getting apps list"))
-            error("Not reached, ignore return type")
+            val exception = IOException("Error getting apps list")
+            acraWrapper.logException(exception)
+            throw exception
         }
     }
 

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -1,5 +1,7 @@
 package tech.ula.model.repositories
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.remote.GithubApiClient
@@ -95,7 +97,7 @@ class AssetRepository(
         return lists
     }
 
-    private suspend fun fetchAssetList(assetType: String): List<Asset> {
+    private suspend fun fetchAssetList(assetType: String): List<Asset> = withContext(Dispatchers.IO) {
         val downloadUrl = githubApiClient.getAssetsListDownloadUrl(assetType)
 
         val inputStream = connectionUtility.getUrlInputStream(downloadUrl)
@@ -110,7 +112,7 @@ class AssetRepository(
 
         reader.close()
 
-        return assetList
+        return@withContext assetList
     }
 
     private suspend fun lastDownloadedVersionIsUpToDate(repo: String): Boolean {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -235,8 +235,9 @@ class BuildWrapper {
                     isSupported(it)
                 }
         return if (supportedABIS.size == 1 && supportedABIS[0] == "") {
-            AcraWrapper().logAndThrow(IllegalStateException("No supported ABI!"))
-            error("never reached, ignore return type")
+            val exception = IllegalStateException("No supported ABI!")
+            AcraWrapper().logException(exception)
+            throw exception
         } else {
             supportedABIS[0]
         }
@@ -370,13 +371,13 @@ class AcraWrapper {
     fun putCustomString(key: String, value: String) {
         ACRA.getErrorReporter().putCustomData(key, value)
     }
-    @Throws(Exception::class)
-    fun logAndThrow(err: Exception) {
+
+    fun logException(err: Exception): Exception {
         val topOfStackTrace = err.stackTrace.first()
         val key = "Exception: ${topOfStackTrace.fileName}"
         val value = "${topOfStackTrace.lineNumber}"
         ACRA.getErrorReporter().putCustomData(key, value)
-        throw err
+        return err
     }
 }
 

--- a/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
+++ b/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
@@ -13,7 +13,11 @@ class AssetFileClearer(
 ) {
     @Throws(Exception::class)
     suspend fun clearAllSupportAssets() {
-        if (!filesDir.exists()) acraWrapper.logAndThrow(FileNotFoundException())
+        if (!filesDir.exists()) {
+            val exception = FileNotFoundException()
+            acraWrapper.logException(exception)
+            throw exception
+        }
         clearFilesystemSupportAssets()
         clearTopLevelAssets(assetDirectoryNames)
     }
@@ -27,13 +31,17 @@ class AssetFileClearer(
             // Removing the support directory must happen last since it contains busybox
             if (file.name == supportDirName) continue
             if (busyboxExecutor.recursivelyDelete(file.absolutePath) !is SuccessfulExecution) {
-                acraWrapper.logAndThrow(IOException())
+                val exception = IOException()
+                acraWrapper.logException(exception)
+                throw exception
             }
         }
         val supportDir = File("${filesDir.absolutePath}/$supportDirName")
         if (supportDir.exists()) {
             if (busyboxExecutor.recursivelyDelete(supportDir.absolutePath) !is SuccessfulExecution) {
-                acraWrapper.logAndThrow(IOException())
+                val exception = IOException()
+                acraWrapper.logException(exception)
+                throw exception
             }
         }
     }
@@ -51,7 +59,9 @@ class AssetFileClearer(
                 if (supportFile.isDirectory || supportFile.name.first() == '.') continue
                 // Use deleteRecursively to match functionality above
                 if (busyboxExecutor.recursivelyDelete(supportFile.path) !is SuccessfulExecution) {
-                    acraWrapper.logAndThrow(IOException())
+                    val exception = IOException()
+                    acraWrapper.logException(exception)
+                    throw exception
                 }
             }
         }

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -115,7 +115,9 @@ class FilesystemUtility(
         if (!filesystemDirectory.exists() || !filesystemDirectory.isDirectory) return
         val result = busyboxExecutor.recursivelyDelete(filesystemDirectory.absolutePath)
         if (result is FailedExecution) {
-            acraWrapper.logAndThrow(IOException())
+            val err = IOException()
+            acraWrapper.logException(err)
+            throw err
         }
     }
 
@@ -131,7 +133,9 @@ class FilesystemUtility(
             appFilesystemProfileDDir.mkdirs()
             appScriptSource.copyTo(appScriptProfileDTarget, overwrite = true)
         } catch (err: Exception) {
-            acraWrapper.logAndThrow(IOException())
+            val exception = IOException()
+            acraWrapper.logException(exception)
+            throw exception
         }
     }
 }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -7,6 +7,7 @@ import android.arch.lifecycle.ViewModelProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import tech.ula.R
 import tech.ula.model.entities.App
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.entities.Session
@@ -279,10 +280,13 @@ class MainActivityViewModel(
         return when (newState) {
             is GeneratingDownloadRequirements -> state.postValue(CheckingForAssetsUpdates)
             is UnexpectedDownloadGenerationSize -> {
-                // TODO post illegal state
+                state.postValue(ErrorGeneratingDownloads(R.string.illegal_state_unexpected_generation_size))
             }
             is UnexpectedDownloadGenerationTypes -> {
-                // TODO post illegal state
+                state.postValue(ErrorGeneratingDownloads(R.string.illegal_state_unexpected_generation_type))
+            }
+            is RemoteUnreachableForGeneration -> {
+                state.postValue(ErrorGeneratingDownloads(R.string.illegal_state_remote_unreachable_during_generation))
             }
             is DownloadsRequired -> {
                 if (newState.largeDownloadRequired) {
@@ -396,13 +400,16 @@ sealed class IllegalState : State()
 data class IllegalStateTransition(val transition: String) : IllegalState()
 object TooManySelectionsMadeWhenPermissionsGranted : IllegalState()
 object NoSelectionsMadeWhenPermissionsGranted : IllegalState()
+
 object NoFilesystemSelectedWhenCredentialsSubmitted : IllegalState()
 object NoAppSelectedWhenPreferenceSubmitted : IllegalState()
 object NoAppSelectedWhenTransitionNecessary : IllegalState()
 object ErrorFetchingAppDatabaseEntries : IllegalState()
 object ErrorCopyingAppScript : IllegalState()
+
 object NoSessionSelectedWhenTransitionNecessary : IllegalState()
 object ErrorFetchingAssetLists : IllegalState()
+data class ErrorGeneratingDownloads(val errorId: Int) : IllegalState()
 data class DownloadsDidNotCompleteSuccessfully(val reason: String) : IllegalState()
 object DownloadCacheAccessedWhileEmpty : IllegalState()
 object DownloadCacheAccessedInAnIncorrectState : IllegalState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,18 @@
 
     <string name="illegal_state_no_session_selected_when_preparation_started">Trying to handle session preparation before one has been selected.</string>
     <string name="illegal_state_error_fetching_asset_lists">Failed to retrieve asset lists.</string>
+
+    <string name="illegal_state_unexpected_generation_size">
+        Unexpected size found while generating download requirements.
+    </string>
+    <string name="illegal_state_unexpected_generation_type">
+        Unexpected type found while generating download requirements.
+    </string>
+    <string name="illegal_state_remote_unreachable_during_generation">
+        Could not reach remote host while generating download requirements. Make sure you have a
+        strong network connection and try again.
+    </string>
+
     <string name="illegal_state_downloads_did_not_complete_successfully">Downloads have failed due to: %1$s.</string>
     <string name="illegal_state_failed_to_copy_assets_to_local">Failed to copy assets to local storage. Try clearing support files.</string>
     <string name="illegal_state_assets_have_not_been_downloaded">Assets need to be copied to your filesystem, but it looks like they have not been downloaded. Try clearing support files.</string>

--- a/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
+++ b/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
@@ -1,6 +1,5 @@
 package tech.ula.model.remote
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -140,12 +139,10 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getAssetsListDownloadUrl(testRepo) }
 
-        verify(mockAcraWrapper.logAndThrow(IOException()))
+        verify(mockAcraWrapper.logException(IOException()))
     }
 
     @Test
@@ -185,12 +182,10 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getLatestReleaseVersion(testRepo) }
 
-        verify(mockAcraWrapper.logAndThrow(IOException()))
+        verify(mockAcraWrapper.logException(IOException()))
     }
 
     @Test
@@ -230,12 +225,10 @@ class GithubApiClientTest {
         response.setResponseCode(500)
         server.enqueue(response)
         stubBaseUrl()
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(IOException())
 
         runBlocking { githubApiClient.getAssetEndpoint(testAssetType, testRepo) }
 
-        verify(mockAcraWrapper).logAndThrow(IOException())
+        verify(mockAcraWrapper).logException(IOException())
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -107,15 +107,12 @@ class AssetRepositoryTest {
     @Test(expected = IllegalStateException::class)
     fun `generateDownloadRequirements logs and throws and exception if sent an empty asset list`() {
         val assetLists = hashMapOf(supportRepo to listOf<Asset>())
-        val exception = IllegalStateException()
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(exception)
 
         runBlocking {
             assetRepository.generateDownloadRequirements(filesystem, assetLists, true)
         }
 
-        verify(mockAcraWrapper).logAndThrow(exception)
+        verify(mockAcraWrapper).logException(IOException())
     }
 
     @Test

--- a/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
@@ -79,12 +79,10 @@ class AssetFileClearerTest {
     @Test(expected = FileNotFoundException::class)
     fun `Throws FileNotFoundException if files directory does not exist`() {
         filesDir.deleteRecursively()
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(FileNotFoundException())
 
         runBlocking { assetFileClearer.clearAllSupportAssets() }
 
-        verify(mockAcraWrapper.logAndThrow(FileNotFoundException()))
+        verify(mockAcraWrapper.logException(FileNotFoundException()))
     }
 
     @Test

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -356,8 +356,6 @@ class FilesystemUtilityTest {
         val testDir = File("${tempFolder.root.path}/100")
         testDir.mkdirs()
         assertTrue(testDir.exists() && testDir.isDirectory)
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(IOException())
 
         runBlocking {
             whenever(mockBusyboxExecutor.recursivelyDelete(testDir.absolutePath))
@@ -365,7 +363,7 @@ class FilesystemUtilityTest {
             filesystemUtility.deleteFilesystem(100)
         }
         verifyBlocking(mockBusyboxExecutor) { recursivelyDelete(testDir.absolutePath) }
-        verify(mockAcraWrapper).logAndThrow(IOException())
+        verify(mockAcraWrapper).logException(IOException())
     }
 
     @Test
@@ -397,11 +395,8 @@ class FilesystemUtilityTest {
         val sourceAppScriptDir = File("${tempFolder.root.absolutePath}/apps/$sourceAppName")
         sourceAppScriptDir.mkdirs()
 
-        whenever(mockAcraWrapper.logAndThrow(any()))
-                .thenThrow(IOException())
-
         filesystemUtility.moveAppScriptToRequiredLocation(sourceAppName, filesystem)
 
-        verify(mockAcraWrapper).logAndThrow(IOException())
+        verify(mockAcraWrapper).logException(IOException())
     }
 }


### PR DESCRIPTION
**Describe the pull request**

Currently, we're seeing a fair number of crashes because the `GithubApiClient` fails to resolve Github as a hostname. As far as I can tell, this is usually just a connectivity issue. This PR adds an explicit error for when this happens during the download generation stage. It also improves the Acra exception logging introduced last week to improve readability and testability.

**Link to relevant issues**
N/A