### PR TITLE
Download generation fix

### DIFF
--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -1,6 +1,5 @@
 package tech.ula.model.repositories
 
-import android.accounts.NetworkErrorException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import tech.ula.model.entities.Asset

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -1,5 +1,6 @@
 package tech.ula.model.repositories
 
+import android.accounts.NetworkErrorException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import tech.ula.model.entities.Asset
@@ -41,21 +42,41 @@ class AssetRepository(
             val (repo, list) = entry
             // Empty lists should not have propagated this deeply.
             if (list.isEmpty()) {
-                val err = java.lang.IllegalStateException()
+                val err = IllegalStateException()
                 acraWrapper.logException(err)
                 throw err
             }
-            if (assetsArePresentInSupportDirectories(list) && lastDownloadedVersionIsUpToDate(repo))
-                continue
+            if (assetsArePresentInSupportDirectories(list)) {
+                try {
+                    if (lastDownloadedVersionIsUpToDate(repo)) {
+                        continue
+                    }
+                } catch (err: UnknownHostException) {
+                    // If assets are present but the network is unreachable, don't bother trying
+                    // to find updates.
+                    break
+                }
+            }
             val filename = "assets.tar.gz"
             val versionCode = githubApiClient.getLatestReleaseVersion(repo)
             val url = githubApiClient.getAssetEndpoint(filename, repo)
             val downloadMetadata = DownloadMetadata(filename, repo, versionCode, url)
             downloadRequirements.add(downloadMetadata)
         }
-        if (filesystemNeedsExtraction && rootFsDownloadRequired(filesystem)) {
+        if (filesystemNeedsExtraction) {
             val repo = filesystem.distributionType
             val filename = "rootfs.tar.gz"
+
+            val rootFsIsDownloaded = File("$applicationFilesDirPath/$repo/$filename").exists()
+            val rootFsIsUpToDate = try {
+                lastDownloadedFilesystemVersionIsUpToDate(repo)
+            } catch (err: UnknownHostException) {
+                // Allows usage of existing rootfs files in case of failing network connectivity.
+                true
+            }
+            if (rootFsIsDownloaded && rootFsIsUpToDate) return downloadRequirements
+
+            // If the rootfs is not downloaded, network failures will still propagate.
             val versionCode = githubApiClient.getLatestReleaseVersion(repo)
             val url = githubApiClient.getAssetEndpoint(filename, repo)
             val downloadMetadata = DownloadMetadata(filename, repo, versionCode, url)
@@ -125,10 +146,5 @@ class AssetRepository(
         val latestCached = assetPreferences.getLatestDownloadFilesystemVersion(repo)
         val latestRemote = githubApiClient.getLatestReleaseVersion(repo)
         return latestCached >= latestRemote
-    }
-
-    private suspend fun rootFsDownloadRequired(filesystem: Filesystem): Boolean {
-        val rootFsFile = File("$applicationFilesDirPath/${filesystem.distributionType}/rootfs.tar.gz")
-        return !rootFsFile.exists() || !lastDownloadedFilesystemVersionIsUpToDate(filesystem.distributionType)
     }
 }


### PR DESCRIPTION
**Describe the pull request**

Previously, we were allowing network failures during download generation to propagate regardless of whether assets were already downloaded. Network attempts are made every time a session is starting to see if there are updates to assets. This PR will allow failed network attempts to be ignored if the assets being checked for updates exist already in support directories. This will allow users to use UserLAnd offline once they have completed the setup process.

**Link to relevant issues**
Closes #753
