### PR TITLE
Display storage capacity warning when low on storage

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -288,7 +288,14 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             viewModel.waitForPermissions(appToContinue = app)
             return
         }
-        viewModel.submitAppSelection(app)
+
+        if (getAvailableStorageInMB() < 1000) {
+            displayGenericErrorDialog(this, R.string.alert_storage_low_title, R.string.alert_storage_low_message, R.string.button_continue) {
+                viewModel.submitAppSelection(app)
+            }
+        } else {
+            viewModel.submitAppSelection(app)
+        }
     }
 
     override fun sessionHasBeenSelected(session: Session) {
@@ -297,7 +304,14 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             viewModel.waitForPermissions(sessionToContinue = session)
             return
         }
-        viewModel.submitSessionSelection(session)
+
+        if (getAvailableStorageInMB() < 1000) {
+            displayGenericErrorDialog(this, R.string.alert_storage_low_title, R.string.alert_storage_low_message, R.string.button_continue) {
+                viewModel.submitSessionSelection(session)
+            }
+        } else {
+            viewModel.submitSessionSelection(session)
+        }
     }
 
     private fun handleStateUpdate(newState: State) {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -13,6 +13,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.os.StatFs
 import android.support.v4.content.ContextCompat
 import android.util.DisplayMetrics
 import android.view.WindowManager
@@ -46,12 +47,13 @@ fun arePermissionsGranted(context: Context): Boolean {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 }
 
-fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int) {
+fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int, buttonId: Int = R.string.button_ok, callback: (() -> Unit)? = null) {
     AlertDialog.Builder(activity)
             .setTitle(titleId)
             .setMessage(messageId)
-            .setPositiveButton(R.string.button_ok) {
+            .setPositiveButton(buttonId) {
                 dialog, _ ->
+                callback?.let { it() }
                 dialog.dismiss()
             }
             .create().show()
@@ -64,6 +66,13 @@ fun getBranchToDownloadAssetsFrom(assetType: String): String {
         "apps" -> "master"
         else -> "master"
     }
+}
+
+fun getAvailableStorageInMB(): Long {
+    val bytesInMB = 1048576
+    val stat = StatFs(Environment.getExternalStorageDirectory().path)
+    val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+    return bytesAvailable / bytesInMB
 }
 
 class DefaultPreferences(private val prefs: SharedPreferences) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,10 @@
     <!-- Network unavailable alert -->
     <string name="alert_network_required_for_refresh">Refreshing apps requires an available or stronger network connection.</string>
 
+    <!-- Storage capacity low alert -->
+    <string name="alert_storage_low_title">Low storage capacity</string>
+    <string name="alert_storage_low_message">To ensure smooth functionality of a filesystem in UserLAnd, ensure there is at least 1 GB of free space.</string>
+
     <!-- Wifi alert -->
     <string name="alert_wifi_disabled_title">No wifi!</string>
     <string name="alert_wifi_disabled_message">A large asset (~80mb) needs to be downloaded.</string>


### PR DESCRIPTION
**Describe the pull request**
When the available storage on a device is less than 1 gb, and the user attempts to start a session or an app, warn them that Userland works best when there is at least 1gb of available space.  This will still allow them to continue with starting the session/app if they want to.

**Link to relevant issues**
