### PR TITLE
Add Storage capacity warning when device is low in memory

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -400,6 +400,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private fun handleUserInputState(state: UserInputRequiredState) {
         acraWrapper.putCustomString("Last handled user input state", "$state")
         return when (state) {
+            is LowStorageAcknowledgementRequired -> {
+                displayLowStorageDialog()
+            }
             is FilesystemCredentialsRequired -> {
                 getCredentials()
             }
@@ -478,6 +481,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             }
             is FailedToClearSupportFiles -> {
                 getString(R.string.illegal_state_failed_to_clear_support_files)
+            }
+            is InsufficientAvailableStorage -> {
+                getString(R.string.illegal_state_insufficient_storage)
             }
         }
         displayIllegalStateDialog(reason)
@@ -592,6 +598,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             is CopyingDownloads -> {
                 val step = getString(R.string.progress_copying_downloads)
                 updateProgressBar(step, "")
+            }
+            is VerifyingAvailableStorage -> {
+                killProgressBar()
             }
             is FilesystemExtractionStep -> {
                 val step = getString(R.string.progress_setting_up_filesystem)
@@ -716,6 +725,12 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
             viewModel.handleUserInputCancelled()
         }
         customDialog.show()
+    }
+
+    private fun displayLowStorageDialog() {
+        displayGenericErrorDialog(this, R.string.alert_storage_low_title, R.string.alert_storage_low_message) {
+            viewModel.lowAvailableStorageAcknowledged()
+        }
     }
 
     private fun getServiceTypePreference() {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -19,6 +19,7 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.os.StatFs
 import android.support.design.widget.TextInputEditText
 import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AppCompatActivity
@@ -124,6 +125,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
         val busyboxExecutor = BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), DefaultPreferences(defaultSharedPreferences))
         val filesystemUtility = FilesystemUtility(filesDir.path, busyboxExecutor)
+        val storageUtility = StorageUtility(StatFs(Environment.getExternalStorageDirectory().path))
 
         val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val downloadManagerWrapper = DownloadManagerWrapper(downloadManager)
@@ -132,7 +134,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         val appsPreferences = AppsPreferences(this.getSharedPreferences("apps", Context.MODE_PRIVATE))
 
         val appsStartupFsm = AppsStartupFsm(ulaDatabase, appsPreferences, filesystemUtility)
-        val sessionStartupFsm = SessionStartupFsm(ulaDatabase, assetRepository, filesystemUtility, downloadUtility)
+        val sessionStartupFsm = SessionStartupFsm(ulaDatabase, assetRepository, filesystemUtility, downloadUtility, storageUtility)
         ViewModelProviders.of(this, MainActivityViewModelFactory(appsStartupFsm, sessionStartupFsm))
                 .get(MainActivityViewModel::class.java)
     }

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -599,6 +599,10 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 val step = getString(R.string.progress_copying_downloads)
                 updateProgressBar(step, "")
             }
+            is VerifyingFilesystem -> {
+                val step = getString(R.string.progress_verifying_assets)
+                updateProgressBar(step, "")
+            }
             is VerifyingAvailableStorage -> {
                 val step = getString(R.string.progress_verifying_sufficient_storage)
                 updateProgressBar(step, "")
@@ -607,10 +611,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 val step = getString(R.string.progress_setting_up_filesystem)
                 val details = getString(R.string.progress_extraction_details, state.extractionTarget)
                 updateProgressBar(step, details)
-            }
-            is VerifyingFilesystem -> {
-                val step = getString(R.string.progress_verifying_assets)
-                updateProgressBar(step, "")
             }
             is ClearingSupportFiles -> {
                 val step = getString(R.string.progress_clearing_support_files)

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -600,7 +600,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 updateProgressBar(step, "")
             }
             is VerifyingAvailableStorage -> {
-                killProgressBar()
+                val step = getString(R.string.progress_verifying_sufficient_storage)
+                updateProgressBar(step, "")
             }
             is FilesystemExtractionStep -> {
                 val step = getString(R.string.progress_setting_up_filesystem)

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -20,6 +20,7 @@ class SessionStartupFsm(
     private val assetRepository: AssetRepository,
     private val filesystemUtility: FilesystemUtility,
     private val downloadUtility: DownloadUtility,
+    private val storageUtility: StorageUtility,
     private val acraWrapper: AcraWrapper = AcraWrapper()
 ) {
 
@@ -266,9 +267,8 @@ class SessionStartupFsm(
 
     private fun handleVerifyAvailableStorage() {
         state.postValue(VerifyingSufficientStorage)
-        val availableStorage: Long = getAvailableStorageInMB()
 
-        when (availableStorage) {
+        when (storageUtility.getAvailableStorageInMB()) {
             in 0..250 -> state.postValue(VerifyingSufficientStorageFailed)
             in 251..1000 -> state.postValue(LowAvailableStorage)
             else -> state.postValue(StorageVerificationComplete)

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -86,7 +86,7 @@ class SessionStartupFsm(
             is VerifyFilesystemAssets -> currentState is NoDownloadsRequired || currentState is LocalDirectoryCopySucceeded
             is VerifyAvailableStorage -> currentState is FilesystemAssetVerificationSucceeded
             is VerifyAvailableStorageComplete -> currentState is VerifyingSufficientStorage || currentState is LowAvailableStorage
-            is ExtractFilesystem -> currentState is StorageVerificationComplete
+            is ExtractFilesystem -> currentState is StorageVerificationCompletedSuccessfully
             is ResetSessionState -> true
         }
     }
@@ -271,12 +271,12 @@ class SessionStartupFsm(
         when (storageUtility.getAvailableStorageInMB()) {
             in 0..250 -> state.postValue(VerifyingSufficientStorageFailed)
             in 251..1000 -> state.postValue(LowAvailableStorage)
-            else -> state.postValue(StorageVerificationComplete)
+            else -> state.postValue(StorageVerificationCompletedSuccessfully)
         }
     }
 
     private fun handleVerifyAvailableStorageComplete() {
-        state.postValue(StorageVerificationComplete)
+        state.postValue(StorageVerificationCompletedSuccessfully)
     }
 
     private suspend fun handleExtractFilesystem(filesystem: Filesystem) {
@@ -353,7 +353,7 @@ sealed class StorageVerificationState : SessionStartupState()
 object VerifyingSufficientStorage : StorageVerificationState()
 object VerifyingSufficientStorageFailed : StorageVerificationState()
 object LowAvailableStorage : StorageVerificationState()
-object StorageVerificationComplete : StorageVerificationState()
+object StorageVerificationCompletedSuccessfully : StorageVerificationState()
 
 sealed class SessionStartupEvent
 data class SessionSelected(val session: Session) : SessionStartupEvent()

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -83,7 +83,9 @@ class SessionStartupFsm(
             }
             is CopyDownloadsToLocalStorage -> currentState is DownloadsHaveSucceeded
             is VerifyFilesystemAssets -> currentState is NoDownloadsRequired || currentState is LocalDirectoryCopySucceeded
-            is ExtractFilesystem -> currentState is FilesystemAssetVerificationSucceeded
+            is VerifyAvailableStorage -> currentState is FilesystemAssetVerificationSucceeded
+            is VerifyAvailableStorageComplete -> currentState is VerifyingSufficientStorage || currentState is LowAvailableStorage
+            is ExtractFilesystem -> currentState is StorageVerificationComplete
             is ResetSessionState -> true
         }
     }
@@ -104,6 +106,8 @@ class SessionStartupFsm(
             is SyncDownloadState -> { handleSyncDownloadState() }
             is CopyDownloadsToLocalStorage -> { handleCopyDownloadsToLocalDirectories() }
             is VerifyFilesystemAssets -> { handleVerifyFilesystemAssets(event.filesystem) }
+            is VerifyAvailableStorage -> { handleVerifyAvailableStorage() }
+            is VerifyAvailableStorageComplete -> { handleVerifyAvailableStorageComplete() }
             is ExtractFilesystem -> { handleExtractFilesystem(event.filesystem) }
             is ResetSessionState -> { state.postValue(WaitingForSessionSelection) }
         }
@@ -260,6 +264,21 @@ class SessionStartupFsm(
         state.postValue(FilesystemAssetVerificationSucceeded)
     }
 
+    private fun handleVerifyAvailableStorage() {
+        state.postValue(VerifyingSufficientStorage)
+        val availableStorage: Long = getAvailableStorageInMB()
+
+        when (availableStorage) {
+            in 0..250 -> state.postValue(VerifyingSufficientStorageFailed)
+            in 251..1000 -> state.postValue(LowAvailableStorage)
+            else -> state.postValue(StorageVerificationComplete)
+        }
+    }
+
+    private fun handleVerifyAvailableStorageComplete() {
+        state.postValue(StorageVerificationComplete)
+    }
+
     private suspend fun handleExtractFilesystem(filesystem: Filesystem) {
         val filesystemDirectoryName = "${filesystem.id}"
 
@@ -330,6 +349,12 @@ data class ExtractingFilesystem(val extractionTarget: String) : ExtractionState(
 object ExtractionHasCompletedSuccessfully : ExtractionState()
 data class ExtractionFailed(val reason: String) : ExtractionState()
 
+sealed class StorageVerificationState : SessionStartupState()
+object VerifyingSufficientStorage : StorageVerificationState()
+object VerifyingSufficientStorageFailed : StorageVerificationState()
+object LowAvailableStorage : StorageVerificationState()
+object StorageVerificationComplete : StorageVerificationState()
+
 sealed class SessionStartupEvent
 data class SessionSelected(val session: Session) : SessionStartupEvent()
 data class RetrieveAssetLists(val filesystem: Filesystem) : SessionStartupEvent()
@@ -339,5 +364,7 @@ data class AssetDownloadComplete(val downloadAssetId: Long) : SessionStartupEven
 object SyncDownloadState : SessionStartupEvent()
 object CopyDownloadsToLocalStorage : SessionStartupEvent()
 data class VerifyFilesystemAssets(val filesystem: Filesystem) : SessionStartupEvent()
+object VerifyAvailableStorage : SessionStartupEvent()
+object VerifyAvailableStorageComplete : SessionStartupEvent()
 data class ExtractFilesystem(val filesystem: Filesystem) : SessionStartupEvent()
 object ResetSessionState : SessionStartupEvent()

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -47,7 +47,7 @@ fun arePermissionsGranted(context: Context): Boolean {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 }
 
-fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int, callback: (() -> Unit)? = null) {
+fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int, callback: (() -> Unit) = {}) {
     AlertDialog.Builder(activity)
             .setTitle(titleId)
             .setMessage(messageId)

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -68,12 +68,11 @@ fun getBranchToDownloadAssetsFrom(assetType: String): String {
     }
 }
 
-class StorageUtility(statFs: StatFs) {
-    private val stat = statFs
+class StorageUtility(private val statFs: StatFs) {
 
     fun getAvailableStorageInMB(): Long {
         val bytesInMB = 1048576
-        val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+        val bytesAvailable = statFs.blockSizeLong * statFs.availableBlocksLong
         return bytesAvailable / bytesInMB
     }
 }

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -47,12 +47,13 @@ fun arePermissionsGranted(context: Context): Boolean {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 }
 
-fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int) {
+fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int, callback: (() -> Unit)? = null) {
     AlertDialog.Builder(activity)
             .setTitle(titleId)
             .setMessage(messageId)
             .setPositiveButton(R.string.button_ok) {
                 dialog, _ ->
+                callback?.let { it() }
                 dialog.dismiss()
             }
             .create().show()

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -13,6 +13,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.os.StatFs
 import android.support.v4.content.ContextCompat
 import android.util.DisplayMetrics
 import android.view.WindowManager
@@ -64,6 +65,13 @@ fun getBranchToDownloadAssetsFrom(assetType: String): String {
         "apps" -> "master"
         else -> "master"
     }
+}
+
+fun getAvailableStorageInMB(): Long {
+    val bytesInMB = 1048576
+    val stat = StatFs(Environment.getExternalStorageDirectory().path)
+    val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+    return bytesAvailable / bytesInMB
 }
 
 class DefaultPreferences(private val prefs: SharedPreferences) {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -53,7 +53,7 @@ fun displayGenericErrorDialog(activity: Activity, titleId: Int, messageId: Int, 
             .setMessage(messageId)
             .setPositiveButton(R.string.button_ok) {
                 dialog, _ ->
-                callback?.let { it() }
+                callback()
                 dialog.dismiss()
             }
             .create().show()

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -68,11 +68,14 @@ fun getBranchToDownloadAssetsFrom(assetType: String): String {
     }
 }
 
-fun getAvailableStorageInMB(): Long {
-    val bytesInMB = 1048576
-    val stat = StatFs(Environment.getExternalStorageDirectory().path)
-    val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
-    return bytesAvailable / bytesInMB
+class StorageUtility(statFs: StatFs) {
+    private val stat = statFs
+
+    fun getAvailableStorageInMB(): Long {
+        val bytesInMB = 1048576
+        val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+        return bytesAvailable / bytesInMB
+    }
 }
 
 class DefaultPreferences(private val prefs: SharedPreferences) {

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -353,7 +353,7 @@ class MainActivityViewModel(
             is VerifyingSufficientStorage -> state.postValue(VerifyingAvailableStorage)
             is VerifyingSufficientStorageFailed -> state.postValue(InsufficientAvailableStorage)
             is LowAvailableStorage -> state.postValue(LowStorageAcknowledgementRequired)
-            is StorageVerificationComplete -> { doTransitionIfRequirementsAreSelected {
+            is StorageVerificationCompletedSuccessfully -> { doTransitionIfRequirementsAreSelected {
                 submitSessionStartupEvent(ExtractFilesystem(lastSelectedFilesystem))
             } }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="progress_downloading">Downloading required assets&#8230;</string>
     <string name="progress_downloading_out_of">%1$d out of %2$d complete</string>
     <string name="progress_copying_downloads">Copying downloaded files to local storage&#8230;</string>
+    <string name="progress_verifying_sufficient_storage">Verifying sufficient storage available</string>
     <string name="progress_setting_up_filesystem">Setting up filesystem&#8230;</string>
     <string name="progress_extraction_details">Extracting: %1$s</string>
     <string name="progress_verifying_assets">Verifying assets&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,10 @@
     <!-- Network unavailable alert -->
     <string name="alert_network_required_for_refresh">Refreshing apps requires an available or stronger network connection.</string>
 
+    <!-- Storage capacity low alert -->
+    <string name="alert_storage_low_title">Low storage capacity</string>
+    <string name="alert_storage_low_message">To ensure smooth functionality of a filesystem in UserLAnd, ensure there is at least 1 GB of free space.</string>
+
     <!-- Wifi alert -->
     <string name="alert_wifi_disabled_title">No wifi!</string>
     <string name="alert_wifi_disabled_message">A large asset (~80mb) needs to be downloaded.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="illegal_state_failed_to_copy_assets_to_filesystem">Failed to copy assets to filesystem. Try clearing support files.</string>
     <string name="illegal_state_failed_to_extract_filesystem">Failed to extract filesystem. Try clearing support files. Failure reason: %1$s</string>
     <string name="illegal_state_failed_to_clear_support_files">Failed to clear support files.</string>
+    <string name="illegal_state_insufficient_storage">Failed to detect sufficient storage.  Try increasing the available storage on your device to at least 250 MB.</string>
 
     <!-- Misc illegal state -->
     <string name="illegal_state_unhandled_session_service_type">Trying to start a session with an unknown service type.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
     <string name="progress_downloading">Downloading required assets&#8230;</string>
     <string name="progress_downloading_out_of">%1$d out of %2$d complete</string>
     <string name="progress_copying_downloads">Copying downloaded files to local storage&#8230;</string>
-    <string name="progress_verifying_sufficient_storage">Verifying sufficient storage available</string>
+    <string name="progress_verifying_sufficient_storage">Verifying sufficient storage available&#8230;</string>
     <string name="progress_setting_up_filesystem">Setting up filesystem&#8230;</string>
     <string name="progress_extraction_details">Extracting: %1$s</string>
     <string name="progress_verifying_assets">Verifying assets&#8230;</string>

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -747,7 +747,7 @@ class SessionStartupFsmTest {
     }
 
     @Test
-    fun `State is not  if device has greater than 1GB of storage after VerifyingAvailableStorage`() {
+    fun `State is not VerifyingSufficientStorageFailed or LowAvailableStorage if device has greater than 1GB of storage after VerifyingAvailableStorage`() {
         sessionFsm.setState(FilesystemAssetVerificationSucceeded)
         sessionFsm.getState().observeForever(mockStateObserver)
 
@@ -756,6 +756,7 @@ class SessionStartupFsmTest {
 
         verify(mockStateObserver).onChanged(VerifyingSufficientStorage)
         verify(mockStateObserver, never()).onChanged(VerifyingSufficientStorageFailed)
+        verify(mockStateObserver, never()).onChanged(LowAvailableStorage)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -156,7 +156,7 @@ class SessionStartupFsmTest {
 
                     event is VerifyAvailableStorage && state is FilesystemAssetVerificationSucceeded -> assertTrue(result)
                     event is VerifyAvailableStorageComplete && (state is VerifyingSufficientStorage || state is LowAvailableStorage) -> assertTrue(result)
-                    event is ExtractFilesystem && state is StorageVerificationComplete -> assertTrue(result)
+                    event is ExtractFilesystem && state is StorageVerificationCompletedSuccessfully -> assertTrue(result)
                     event is ResetSessionState -> assertTrue(result)
                     else -> assertFalse(result)
                 }
@@ -760,7 +760,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `Exits early if filesystem is already extracted`() {
-        sessionFsm.setState(StorageVerificationComplete)
+        sessionFsm.setState(StorageVerificationCompletedSuccessfully)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         whenever(mockFilesystemUtility.hasFilesystemBeenSuccessfullyExtracted("${filesystem.id}"))
@@ -774,7 +774,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionSucceeded if extraction succeeds`() {
-        sessionFsm.setState(StorageVerificationComplete)
+        sessionFsm.setState(StorageVerificationCompletedSuccessfully)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         runBlocking {
@@ -793,7 +793,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionFailed and propagates reason for failure`() {
-        sessionFsm.setState(StorageVerificationComplete)
+        sessionFsm.setState(StorageVerificationCompletedSuccessfully)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         val reason = "reason"
@@ -809,7 +809,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionFailed if extraction reportedly succeeds but status file is not created`() {
-        sessionFsm.setState(StorageVerificationComplete)
+        sessionFsm.setState(StorageVerificationCompletedSuccessfully)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         runBlocking {

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -722,7 +722,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `Exits early if filesystem is already extracted`() {
-        sessionFsm.setState(FilesystemAssetVerificationSucceeded)
+        sessionFsm.setState(StorageVerificationComplete)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         whenever(mockFilesystemUtility.hasFilesystemBeenSuccessfullyExtracted("${filesystem.id}"))

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -151,7 +151,10 @@ class SessionStartupFsmTest {
                     event is SyncDownloadState -> assertTrue(result)
                     event is CopyDownloadsToLocalStorage && state is DownloadsHaveSucceeded -> assertTrue(result)
                     event is VerifyFilesystemAssets && (state is NoDownloadsRequired || state is LocalDirectoryCopySucceeded) -> assertTrue(result)
-                    event is ExtractFilesystem && state is FilesystemAssetVerificationSucceeded -> assertTrue(result)
+
+                    event is VerifyAvailableStorage && state is FilesystemAssetVerificationSucceeded -> assertTrue(result)
+                    event is VerifyAvailableStorageComplete && (state is VerifyingSufficientStorage || state is LowAvailableStorage) -> assertTrue(result)
+                    event is ExtractFilesystem && state is StorageVerificationComplete -> assertTrue(result)
                     event is ResetSessionState -> assertTrue(result)
                     else -> assertFalse(result)
                 }
@@ -733,7 +736,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionSucceeded if extraction succeeds`() {
-        sessionFsm.setState(FilesystemAssetVerificationSucceeded)
+        sessionFsm.setState(StorageVerificationComplete)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         runBlocking {
@@ -752,7 +755,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionFailed and propagates reason for failure`() {
-        sessionFsm.setState(FilesystemAssetVerificationSucceeded)
+        sessionFsm.setState(StorageVerificationComplete)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         val reason = "reason"
@@ -768,7 +771,7 @@ class SessionStartupFsmTest {
 
     @Test
     fun `State is ExtractionFailed if extraction reportedly succeeds but status file is not created`() {
-        sessionFsm.setState(FilesystemAssetVerificationSucceeded)
+        sessionFsm.setState(StorageVerificationComplete)
         sessionFsm.getState().observeForever(mockStateObserver)
 
         runBlocking {

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -658,10 +658,21 @@ class MainActivityViewModelTest {
     }
 
     @Test
-    fun `Submits ExtractFilesystem when observing FilesystemAssetVerificationSucceeded`() {
+    fun `Submits VerifyAvailableStorage when observing FilesystemAssetVerificationSucceeded`() {
         makeSessionSelections()
 
         sessionStartupStateLiveData.postValue(FilesystemAssetVerificationSucceeded)
+
+        runBlocking {
+            verify(mockSessionStartupFsm).submitEvent(VerifyAvailableStorage, mainActivityViewModel)
+        }
+    }
+
+    @Test
+    fun `Submits ExtractFilesystem when observing StorageVerificationComplete`() {
+        makeSessionSelections()
+
+        sessionStartupStateLiveData.postValue(StorageVerificationComplete)
 
         runBlocking {
             verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem), mainActivityViewModel)

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -669,10 +669,10 @@ class MainActivityViewModelTest {
     }
 
     @Test
-    fun `Submits ExtractFilesystem when observing StorageVerificationComplete`() {
+    fun `Submits ExtractFilesystem when observing StorageVerificationCompletedSuccessfully`() {
         makeSessionSelections()
 
-        sessionStartupStateLiveData.postValue(StorageVerificationComplete)
+        sessionStartupStateLiveData.postValue(StorageVerificationCompletedSuccessfully)
 
         runBlocking {
             verify(mockSessionStartupFsm).submitEvent(ExtractFilesystem(selectedFilesystem), mainActivityViewModel)


### PR DESCRIPTION
**Describe the pull request**

When the available storage on a device is less than 1 gb but greater than 250MB, and the user attempts to extract a filesystem, warn them that Userland works best when there is at least 1gb of available space. This will still allow them to continue with starting the session/app if they want to.  

But if there is less than 250 MB of storage available, an error message will display telling them to free up some memory and the app will send an illegal state. 


![Screen Shot 2019-04-15 at 4 31 02 PM](https://user-images.githubusercontent.com/11577853/56173095-19477e80-5fa1-11e9-89df-9cf631b9296e.png)
)



![Screen Shot 2019-04-15 at 4 33 04 PM](https://user-images.githubusercontent.com/11577853/56173094-19477e80-5fa1-11e9-97ed-5cd68bf53dc6.png)
)



**Link to relevant issues**
