### PR TITLE
Graceful failure states

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -63,7 +63,6 @@ import org.acra.data.StringFormat
 import org.acra.sender.HttpSender
 import tech.ula.ui.FilesystemListFragment
 import tech.ula.model.repositories.DownloadMetadata
-import kotlin.IllegalStateException
 
 class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection, FilesystemListFragment.ExportFilesystem {
 
@@ -425,70 +424,18 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     }
 
     private fun handleIllegalState(state: IllegalState) {
-        acraWrapper.putCustomString("Last handled illegal state", "$state")
-        val reason: String = when (state) {
-            is IllegalStateTransition -> {
-                getString(R.string.illegal_state_transition, state.transition)
-            }
-            is TooManySelectionsMadeWhenPermissionsGranted -> {
-                getString(R.string.illegal_state_too_many_selections_when_permissions_granted)
-            }
-            is NoSelectionsMadeWhenPermissionsGranted -> {
-                getString(R.string.illegal_state_no_selections_when_permissions_granted)
-            }
-            is NoFilesystemSelectedWhenCredentialsSubmitted -> {
-                getString(R.string.illegal_state_no_filesystem_selected_when_credentials_selected)
-            }
-            is NoAppSelectedWhenPreferenceSubmitted -> {
-                getString(R.string.illegal_state_no_app_selected_when_preference_submitted)
-            }
-            is NoAppSelectedWhenTransitionNecessary -> {
-                getString(R.string.illegal_state_no_app_selected_when_preparation_started)
-            }
-            is ErrorFetchingAppDatabaseEntries -> {
-                getString(R.string.illegal_state_error_fetching_app_database_entries)
-            }
-            is ErrorCopyingAppScript -> {
-                getString(R.string.illegal_state_error_copying_app_script)
-            }
-            is NoSessionSelectedWhenTransitionNecessary -> {
-                getString(R.string.illegal_state_no_session_selected_when_preparation_started)
-            }
-            is ErrorFetchingAssetLists -> {
-                getString(R.string.illegal_state_error_fetching_asset_lists)
-            }
-            is ErrorGeneratingDownloads -> {
-                getString(state.errorId)
-            }
-            is DownloadsDidNotCompleteSuccessfully -> {
-                getString(R.string.illegal_state_downloads_did_not_complete_successfully, state.reason)
-            }
-            is FailedToCopyAssetsToLocalStorage -> {
-                getString(R.string.illegal_state_failed_to_copy_assets_to_local)
-            }
-            is AssetsHaveNotBeenDownloaded -> {
-                getString(R.string.illegal_state_assets_have_not_been_downloaded)
-            }
-            is DownloadCacheAccessedWhileEmpty -> {
-                getString(R.string.illegal_state_empty_download_cache_access)
-            }
-            is DownloadCacheAccessedInAnIncorrectState -> {
-                getString(R.string.illegal_state_download_cache_access_in_incorrect_state)
-            }
-            is FailedToCopyAssetsToFilesystem -> {
-                getString(R.string.illegal_state_failed_to_copy_assets_to_filesystem)
-            }
-            is FailedToExtractFilesystem -> {
-                getString(R.string.illegal_state_failed_to_extract_filesystem, state.reason)
-            }
-            is FailedToClearSupportFiles -> {
-                getString(R.string.illegal_state_failed_to_clear_support_files)
-            }
-            is InsufficientAvailableStorage -> {
-                getString(R.string.illegal_state_insufficient_storage)
-            }
-        }
-        displayIllegalStateDialog(reason)
+        val localizationData = IllegalStateHandler().logAndGetResourceId(state)
+        val stateDescription = getString(localizationData.resId, *localizationData.formatStrings)
+        val displayMessage = getString(R.string.illegal_state_message, stateDescription)
+
+        AlertDialog.Builder(this)
+                .setMessage(displayMessage)
+                .setTitle(R.string.illegal_state_title)
+                .setPositiveButton(R.string.button_ok) {
+                    dialog, _ ->
+                    dialog.dismiss()
+                }
+                .create().show()
     }
 
     // TODO sealed classes?
@@ -502,20 +449,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 displayGenericErrorDialog(this, R.string.alert_need_client_app_title,
                     R.string.alert_need_client_app_message)
         }
-    }
-
-    private fun displayIllegalStateDialog(reason: String) {
-        val message = getString(R.string.illegal_state_message, reason)
-        AlertDialog.Builder(this)
-                .setMessage(message)
-                .setTitle(R.string.illegal_state_title)
-                .setPositiveButton(R.string.button_ok) {
-                    dialog, _ ->
-                    dialog.dismiss()
-                    acraWrapper.putCustomString("Illegal State Crash Reason", reason)
-                    throw IllegalStateException(reason)
-                }
-                .create().show()
     }
 
     private fun displayClearSupportFilesDialog() {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -426,7 +426,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private fun handleIllegalState(state: IllegalState) {
         val localizationData = IllegalStateHandler().logAndGetResourceId(state)
         val stateDescription = getString(localizationData.resId, *localizationData.formatStrings)
-        val displayMessage = getString(R.string.illegal_state_message, stateDescription)
+        val displayMessage = getString(R.string.illegal_state_github_message, stateDescription)
 
         AlertDialog.Builder(this)
                 .setMessage(displayMessage)

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -390,6 +390,10 @@ class AcraWrapper {
         ACRA.getErrorReporter().putCustomData(key, value)
         return err
     }
+
+    fun silentlySendIllegalStateReport() {
+        ACRA.getErrorReporter().handleSilentException(IllegalStateException())
+    }
 }
 
 class DeviceDimensions {

--- a/app/src/main/java/tech/ula/utils/Extensions.kt
+++ b/app/src/main/java/tech/ula/utils/Extensions.kt
@@ -3,10 +3,6 @@ package tech.ula.utils
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
 
-fun currentTimeSeconds(): Long {
-    return System.currentTimeMillis() / 1000
-}
-
 fun <A, B> zipLiveData(a: LiveData<A>, b: LiveData<B>): LiveData<Pair<A, B>> {
     return MediatorLiveData<Pair<A, B>>().apply {
         var lastA: A? = null

--- a/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
+++ b/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
@@ -1,0 +1,92 @@
+package tech.ula.utils
+
+import tech.ula.R
+import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
+import java.util.Arrays
+
+data class LocalizationData(val resId: Int, val formatStrings: Array<String> = arrayOf()) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other?.javaClass != javaClass) return false
+
+        other as LocalizationData
+
+        if (!Arrays.equals(formatStrings, other.formatStrings)) return false
+
+        return resId == other.resId
+    }
+
+    override fun hashCode(): Int {
+        return Arrays.hashCode(formatStrings)
+    }
+}
+
+class IllegalStateHandler(private val acraWrapper: AcraWrapper = AcraWrapper()) {
+
+    fun logAndGetResourceId(state: IllegalState): LocalizationData {
+        acraWrapper.putCustomString("Last handled illegal state", "$state")
+        acraWrapper.silentlySendIllegalStateReport()
+        return when (state) {
+            is IllegalStateTransition -> {
+                LocalizationData(R.string.illegal_state_transition, arrayOf(state.transition))
+            }
+            is TooManySelectionsMadeWhenPermissionsGranted -> {
+                LocalizationData(R.string.illegal_state_too_many_selections_when_permissions_granted)
+            }
+            is NoSelectionsMadeWhenPermissionsGranted -> {
+                LocalizationData(R.string.illegal_state_no_selections_when_permissions_granted)
+            }
+            is NoFilesystemSelectedWhenCredentialsSubmitted -> {
+                LocalizationData(R.string.illegal_state_no_filesystem_selected_when_credentials_selected)
+            }
+            is NoAppSelectedWhenPreferenceSubmitted -> {
+                LocalizationData(R.string.illegal_state_no_app_selected_when_preference_submitted)
+            }
+            is NoAppSelectedWhenTransitionNecessary -> {
+                LocalizationData(R.string.illegal_state_no_app_selected_when_preparation_started)
+            }
+            is ErrorFetchingAppDatabaseEntries -> {
+                LocalizationData(R.string.illegal_state_error_fetching_app_database_entries)
+            }
+            is ErrorCopyingAppScript -> {
+                LocalizationData(R.string.illegal_state_error_copying_app_script)
+            }
+            is NoSessionSelectedWhenTransitionNecessary -> {
+                LocalizationData(R.string.illegal_state_no_session_selected_when_preparation_started)
+            }
+            is ErrorFetchingAssetLists -> {
+                LocalizationData(R.string.illegal_state_error_fetching_asset_lists)
+            }
+            is ErrorGeneratingDownloads -> {
+                LocalizationData(state.errorId)
+            }
+            is DownloadsDidNotCompleteSuccessfully -> {
+                LocalizationData(R.string.illegal_state_downloads_did_not_complete_successfully, arrayOf(state.reason))
+            }
+            is FailedToCopyAssetsToLocalStorage -> {
+                LocalizationData(R.string.illegal_state_failed_to_copy_assets_to_local)
+            }
+            is AssetsHaveNotBeenDownloaded -> {
+                LocalizationData(R.string.illegal_state_assets_have_not_been_downloaded)
+            }
+            is DownloadCacheAccessedWhileEmpty -> {
+                LocalizationData(R.string.illegal_state_empty_download_cache_access)
+            }
+            is DownloadCacheAccessedInAnIncorrectState -> {
+                LocalizationData(R.string.illegal_state_download_cache_access_in_incorrect_state)
+            }
+            is FailedToCopyAssetsToFilesystem -> {
+                LocalizationData(R.string.illegal_state_failed_to_copy_assets_to_filesystem)
+            }
+            is FailedToExtractFilesystem -> {
+                LocalizationData(R.string.illegal_state_failed_to_extract_filesystem, arrayOf(state.reason))
+            }
+            is FailedToClearSupportFiles -> {
+                LocalizationData(R.string.illegal_state_failed_to_clear_support_files)
+            }
+            is InsufficientAvailableStorage -> {
+                LocalizationData(R.string.illegal_state_insufficient_storage)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="error_export_to_external_failed_no_data">Exporting to external directory failed, exported file has no data.</string>
     
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>
+    <string name="illegal_state_message">%1$s \Please let us know about this issue on Github! We are working to resolve these issues.</string>
     <string name="illegal_state_title">UserLAnd has entered an illegal state!</string>
 
     <string name="illegal_state_transition">Bad state transition: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="error_export_to_external_failed_no_data">Exporting to external directory failed, exported file has no data.</string>
     
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \Please let us know about this issue on Github! We are working to resolve these issues.</string>
+    <string name="illegal_state_github_message">%1$s \nThe app will now crash so that we can receive an error log. Feel free to also let us know on Github! We are working to resolve these issues.</string>
     <string name="illegal_state_title">UserLAnd has entered an illegal state!</string>
 
     <string name="illegal_state_transition">Bad state transition: %1$s</string>

--- a/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
+++ b/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
@@ -1,0 +1,267 @@
+package tech.ula.utils
+
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import tech.ula.R
+import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
+
+@RunWith(MockitoJUnitRunner::class)
+class IllegalStateHandlerTest {
+
+    @Mock lateinit var mockAcraWrapper: AcraWrapper
+
+    private lateinit var illegalStateHandler: IllegalStateHandler
+
+    @Before
+    fun setup() {
+        illegalStateHandler = IllegalStateHandler(mockAcraWrapper)
+    }
+
+    @Test
+    fun `IllegalStateTransition returns correct id and strings, silently logging an exception`() {
+        val reason = "reason"
+        val state = IllegalStateTransition(reason)
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_transition
+        val expectedResult = LocalizationData(resId, arrayOf(reason))
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `TooManySelectionsMadeWhenPermissionsGranted returns correct id and strings, silently logging an exception`() {
+        val state = TooManySelectionsMadeWhenPermissionsGranted
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_too_many_selections_when_permissions_granted
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `NoSelectionsMadeWhenPermissionsGranted returns correct id and strings, silently logging an exception`() {
+        val state = NoSelectionsMadeWhenPermissionsGranted
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_no_selections_when_permissions_granted
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `NoFilesystemSelectedWhenCredentialsSubmitted returns correct id and strings, silently logging an exception`() {
+        val state = NoFilesystemSelectedWhenCredentialsSubmitted
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_no_filesystem_selected_when_credentials_selected
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `NoAppSelectedWhenPreferenceSubmitted returns correct id and strings, silently logging an exception`() {
+        val state = NoAppSelectedWhenPreferenceSubmitted
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_no_app_selected_when_preference_submitted
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `NoAppSelectedWhenTransitionNecessary returns correct id and strings, silently logging an exception`() {
+        val state = NoAppSelectedWhenTransitionNecessary
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_no_app_selected_when_preparation_started
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `ErrorFetchingAppDatabaseEntries returns correct id and strings, silently logging an exception`() {
+        val state = ErrorFetchingAppDatabaseEntries
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_error_fetching_app_database_entries
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `ErrorCopyingAppScript returns correct id and strings, silently logging an exception`() {
+        val state = ErrorCopyingAppScript
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_error_copying_app_script
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `NoSessionSelectedWhenTransitionNecessary returns correct id and strings, silently logging an exception`() {
+        val state = NoSessionSelectedWhenTransitionNecessary
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_no_session_selected_when_preparation_started
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `ErrorFetchingAssetLists returns correct id and strings, silently logging an exception`() {
+        val state = ErrorFetchingAssetLists
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_error_fetching_asset_lists
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `ErrorGeneratingDownloads returns correct id and strings, silently logging an exception`() {
+        val state = ErrorGeneratingDownloads(0)
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = 0
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `DownloadsDidNotCompleteSuccessfully returns correct id and strings, silently logging an exception`() {
+        val reason = "reason"
+        val state = DownloadsDidNotCompleteSuccessfully(reason)
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_downloads_did_not_complete_successfully
+        val expectedResult = LocalizationData(resId, arrayOf(reason))
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `FailedToCopyAssetsToLocalStorage returns correct id and strings, silently logging an exception`() {
+        val state = FailedToCopyAssetsToLocalStorage
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_failed_to_copy_assets_to_local
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `AssetsHaveNotBeenDownloaded returns correct id and strings, silently logging an exception`() {
+        val state = AssetsHaveNotBeenDownloaded
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_assets_have_not_been_downloaded
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `DownloadCacheAccessedWhileEmpty returns correct id and strings, silently logging an exception`() {
+        val state = DownloadCacheAccessedWhileEmpty
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_empty_download_cache_access
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `DownloadCacheAccessedInAnIncorrectState returns correct id and strings, silently logging an exception`() {
+        val state = DownloadCacheAccessedInAnIncorrectState
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_download_cache_access_in_incorrect_state
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `FailedToCopyAssetsToFilesystem returns correct id and strings, silently logging an exception`() {
+        val state = FailedToCopyAssetsToFilesystem
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_failed_to_copy_assets_to_filesystem
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `FailedToExtractFilesystem returns correct id and strings, silently logging an exception`() {
+        val reason = "reason"
+        val state = FailedToExtractFilesystem(reason)
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_failed_to_extract_filesystem
+        val expectedResult = LocalizationData(resId, arrayOf(reason))
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `FailedToClearSupportFiles returns correct id and strings, silently logging an exception`() {
+        val state = FailedToClearSupportFiles
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_failed_to_clear_support_files
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+
+    @Test
+    fun `InsufficientAvailableStorage returns correct id and strings, silently logging an exception`() {
+        val state = InsufficientAvailableStorage
+
+        val result = illegalStateHandler.logAndGetResourceId(state)
+
+        val resId = R.string.illegal_state_insufficient_storage
+        val expectedResult = LocalizationData(resId, arrayOf())
+        assertEquals(expectedResult, result)
+        verify(mockAcraWrapper).silentlySendIllegalStateReport()
+    }
+}


### PR DESCRIPTION
**Describe the pull request**

This PR moves the mapping of IllegalState to resource ids to a Utility class, where it also uses silent exception logging. This allows us to continue receiving reports without causing the user to crash.

**Link to relevant issues**
N/A
