### PR TITLE
Remove extra translations.

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -56,7 +56,6 @@
     <string name="error_export_to_external_failed_no_data">أخفق التصدير إلى الدليل الخارجي ، لا يحتوي الملف المصدر على بيانات.</string>
 
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \n سيتم الآن تعطل التطبيق بحيث يمكننا استلام سجل أخطاء. لا تتردد أيضًا في إخبارنا على جيثب! نحن نعمل على حل هذه القضايا.</string>
     <string name="illegal_state_title">لقد دخل UserLAnd حالة غير قانونية!</string>
     <string name="illegal_state_transition">انتقال الحالة السيئة:%1$s</string>
     <string name="illegal_state_too_many_selections_when_permissions_granted">تم اختيار كل من الجلسة والتطبيق عند منح الأذونات.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -57,7 +57,6 @@
 
 
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \nPor favor, reinicia la app y contacta a un desarrollador.</string>
     <string name="illegal_state_title">¡UserLAnd ha entrado en un estado ilegal!</string>
 
     <string name="illegal_state_transition">Mala transición de estado: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -46,7 +46,6 @@
     <string name="error_vnc_password_invalid">Пароль VNC содержит недопустимые знаки</string>
 
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \nСейчас приложение отправит журнал ошибок и завершит работу. Также вы можете сообщить о проблеме на Github! Мы что-нибудь придумаем.</string>
     <string name="illegal_state_title">Приложение UserLAnd перешло в некорректное состояние!</string>
 
     <string name="illegal_state_transition">Переход в некорректное состояние: %1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -57,7 +57,6 @@
     <string name="error_export_to_external_failed_no_data">匯出到外部目錄失敗，已匯出的檔案沒有資料。</string>
 
     <!-- Illegal State Dialog -->
-    <string name="illegal_state_message">%1$s \n應用程式現在將會當掉，這樣我們就可以接收到錯誤紀錄。歡迎在 GitHub 上告訴我們！我們正在努力解決這些問題。</string>
     <string name="illegal_state_title">UserLAnd 已進入違規狀態！</string>
 
     <string name="illegal_state_transition">狀態轉換不良：%1$s</string>


### PR DESCRIPTION
**Describe the pull request**

Removed 'illegal_state_message' string resource so that translations would not continue to tell users the app was about to crash when it wasn't. It needed to be removed from translations containing it for the 'build_release' gradle task to pass.

**Link to relevant issues**
