### PR TITLE
Fix crash when stopping apps.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 59
-        versionName "2.5.5"
+        versionCode 60
+        versionName "2.5.6"
         
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/tech/ula/ui/AppListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/AppListFragment.kt
@@ -183,7 +183,7 @@ class AppListFragment : Fragment(),
         val serviceIntent = Intent(activityContext, ServerService::class.java)
                 .putExtra("type", "stopApp")
                 .putExtra("app", app)
-        activityContext.startForegroundService(serviceIntent)
+        activityContext.startService(serviceIntent)
         return true
     }
 


### PR DESCRIPTION
**Describe the pull request**

Recently changed the call to start `ServerService` to `startForegroundService()` when stopping apps. This call isn't available on lower API levels, which would cause app crashes. This PR reverts the change and preps for a release.

**Link to relevant issues**
N/A