### PR TITLE
Add inlining to silent acra reports.

### DIFF
--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -410,7 +410,8 @@ class AcraWrapper {
         return err
     }
 
-    fun silentlySendIllegalStateReport(state: IllegalState) {
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun silentlySendIllegalStateReport(state: IllegalState) {
         val type = state.javaClass.simpleName
         ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
     }

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -410,9 +410,9 @@ class AcraWrapper {
         return err
     }
 
-    @Suppress("NOTHING_TO_INLINE")
-    inline fun silentlySendIllegalStateReport(state: IllegalState) {
+    fun silentlySendIllegalStateReport(state: IllegalState) {
         val type = state.javaClass.simpleName
+        putCustomString("State when sending silent report", type)
         ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
     }
 }


### PR DESCRIPTION
**Describe the pull request**
This PR inlines the call which actually sends the silent report, which looks necessary to get the log separation I thought would come with the last PR for this.

**Link to relevant issues**
N/A