### PR TITLE
Switch from ACRA to Sentry.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,19 @@ reference:
       name: Decode Play store key
       command: echo $PLAY_KEY | base64 -di > ${HOME}/play-key.json
 
-  export_tracepot_endpoint: &export_tracepot_endpoint
+  configure_sentry: &export_sentry_dsn
     run:
       name: Export tracepot https environment variable
-      command: echo "tracepotHttpsEndpoint=$TRACEPOT_ENDPOINT" >> app/tracepot.properties
+      command: |
+        mkdir app/src/main/resources
+        echo "dsn=$SENTRY_DSN" >> app/src/main/resources/sentry.properties
+        echo "environment=production" >> app/src/main/resources/sentry.properties
+
+
+  set_sentry_environment: &set_sentry_environment
+    run:
+      name: Set Sentry environment to production
+      command: echo "environment=production" >> app/src/main/resources/sentry.properties
 
   early_return_for_forked_pull_requests: &early_return_for_forked_pull_requests
     run:
@@ -145,7 +154,8 @@ jobs:
       - *save_cache
       - *export_android_key
       - *decode_android_key
-      - *export_tracepot_endpoint
+      - *export_sentry_dsn
+      - *set_sentry_environment
       - run:
           name: Run ktlint
           command: ./gradlew ktlint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,19 +102,13 @@ reference:
       name: Decode Play store key
       command: echo $PLAY_KEY | base64 -di > ${HOME}/play-key.json
 
-  configure_sentry: &export_sentry_dsn
+  configure_sentry: &configure_sentry
     run:
       name: Export tracepot https environment variable
       command: |
         mkdir app/src/main/resources
         echo "dsn=$SENTRY_DSN" >> app/src/main/resources/sentry.properties
         echo "environment=production" >> app/src/main/resources/sentry.properties
-
-
-  set_sentry_environment: &set_sentry_environment
-    run:
-      name: Set Sentry environment to production
-      command: echo "environment=production" >> app/src/main/resources/sentry.properties
 
   early_return_for_forked_pull_requests: &early_return_for_forked_pull_requests
     run:
@@ -154,8 +148,7 @@ jobs:
       - *save_cache
       - *export_android_key
       - *decode_android_key
-      - *export_sentry_dsn
-      - *set_sentry_environment
+      - *configure_sentry
       - run:
           name: Run ktlint
           command: ./gradlew ktlint

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ fastlane/metadata/android/*/changelogs
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
-app/tracepot.properties
+app/src/main/resources/sentry.properties
 
 # Freeline
 freeline.py

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,17 +8,8 @@ apply plugin: 'kotlin-kapt'
 
 apply plugin: 'jacoco'
 
-File tracepotPropertiesFile = file("$projectDir/tracepot.properties")
-
 android {
     compileSdkVersion 28
-
-    Properties tracepotProperties = new Properties()
-    if (tracepotPropertiesFile.exists()) {
-        tracepotProperties.load(new FileInputStream(tracepotPropertiesFile))
-    } else {
-        tracepotProperties.put('tracepotHttpsEndpoint', '""')
-    }
 
     defaultConfig {
         applicationId "tech.ula"
@@ -29,7 +20,6 @@ android {
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-        buildConfigField 'String', 'tracepotHttpsEndpoint', tracepotProperties['tracepotHttpsEndpoint']
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,9 +176,10 @@ task jacocoCoverageReportForCi(type: JacocoReport, dependsOn: ['testDebugUnitTes
 }
 
 dependencies {
-    def acra_version = '5.2.1'
     def moshi_version = '1.8.0'
     def okhttp_version = '3.13.1'
+    def sentry_version = '1.7.22'
+    def slf4j_version = '1.7.26'
 
     // Androidx versions
     def room_version = '2.1.0-alpha07'
@@ -203,13 +204,12 @@ dependencies {
     implementation "com.google.android.material:material:$support_library_version"
     implementation "androidx.preference:preference:$preference_version"
     ktlint "com.pinterest:ktlint:0.32.0"
-    implementation "ch.acra:acra-http:$acra_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.squareup.moshi:moshi:$moshi_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     implementation 'org.rauschig:jarchivelib:0.8.0' // v1.0.0 breaks all sdk versions < 26 https://github.com/thrau/jarchivelib/issues/75
-    implementation 'io.sentry:sentry-android:1.7.16'
-    implementation 'org.slf4j:slf4j-nop:1.7.25'
+    implementation "io.sentry:sentry-android:$sentry_version"
+    implementation "org.slf4j:slf4j-nop:$slf4j_version"
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:$mockito_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 62
-        versionName "2.5.8"
+        versionCode 63
+        versionName "2.5.9"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,6 +208,8 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshi_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
     implementation 'org.rauschig:jarchivelib:0.8.0' // v1.0.0 breaks all sdk versions < 26 https://github.com/thrau/jarchivelib/issues/75
+    implementation 'io.sentry:sentry-android:1.7.16'
+    implementation 'org.slf4j:slf4j-nop:1.7.25'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:$mockito_version"

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -3,7 +3,6 @@ package tech.ula
 import android.Manifest
 import android.annotation.TargetApi
 import android.app.AlertDialog
-import android.app.Application
 import android.app.DownloadManager
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -54,11 +53,6 @@ import tech.ula.ui.SessionListFragment
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 import kotlinx.android.synthetic.main.dia_app_select_client.*
-import org.acra.ACRA
-import org.acra.config.CoreConfigurationBuilder
-import org.acra.config.HttpSenderConfigurationBuilder
-import org.acra.data.StringFormat
-import org.acra.sender.HttpSender
 import tech.ula.ui.FilesystemListFragment
 import tech.ula.model.repositories.DownloadMetadata
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -197,7 +197,7 @@ class ServerService : Service() {
         // TODO This could potentially be handled by the main activity (viewmodel) now
         if (filesystemId == (-1).toLong()) {
             val exception = IllegalStateException("Did not receive filesystemId")
-            AcraWrapper().logException(exception)
+            SentryLogger().addExceptionBreadcrumb(exception)
             throw exception
         }
 

--- a/app/src/main/java/tech/ula/model/remote/GithubApiClient.kt
+++ b/app/src/main/java/tech/ula/model/remote/GithubApiClient.kt
@@ -7,8 +7,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import tech.ula.utils.AcraWrapper
 import tech.ula.utils.BuildWrapper
+import tech.ula.utils.Logger
+import tech.ula.utils.SentryLogger
 import java.io.IOException
 import java.net.UnknownHostException
 
@@ -21,7 +22,7 @@ class UrlProvider {
 class GithubApiClient(
     private val buildWrapper: BuildWrapper = BuildWrapper(),
     private val urlProvider: UrlProvider = UrlProvider(),
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
     private val client = OkHttpClient()
     private val latestResults: HashMap<String, ReleasesResponse?> = hashMapOf()
@@ -71,12 +72,12 @@ class GithubApiClient(
         val response = try {
             client.newCall(request).execute()
         } catch (err: UnknownHostException) {
-            acraWrapper.logException(err)
+            logger.addExceptionBreadcrumb(err)
             throw err
         }
         if (!response.isSuccessful) {
             val err = IOException("Unexpected code: $response")
-            acraWrapper.logException(err)
+            logger.addExceptionBreadcrumb(err)
             throw err
         }
 

--- a/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
+++ b/app/src/main/java/tech/ula/model/remote/RemoteAppsSource.kt
@@ -3,9 +3,7 @@ package tech.ula.model.remote
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import tech.ula.model.entities.App
-import tech.ula.utils.AcraWrapper
-import tech.ula.utils.ConnectionUtility
-import tech.ula.utils.getBranchToDownloadAssetsFrom
+import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
@@ -27,7 +25,7 @@ interface RemoteAppsSource {
 class GithubAppsFetcher(
     private val applicationFilesDir: String,
     private val connectionUtility: ConnectionUtility = ConnectionUtility(),
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) : RemoteAppsSource {
 
     // Allows destructing of the list of application elements
@@ -61,7 +59,7 @@ class GithubAppsFetcher(
             appsList.toList()
         } catch (err: Exception) {
             val exception = IOException("Error getting apps list")
-            acraWrapper.logException(exception)
+            logger.addExceptionBreadcrumb(exception)
             throw exception
         }
     }

--- a/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
+++ b/app/src/main/java/tech/ula/model/repositories/AssetRepository.kt
@@ -5,9 +5,7 @@ import kotlinx.coroutines.withContext
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.remote.GithubApiClient
-import tech.ula.utils.AcraWrapper
-import tech.ula.utils.AssetPreferences
-import tech.ula.utils.ConnectionUtility
+import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -27,7 +25,7 @@ class AssetRepository(
     private val assetPreferences: AssetPreferences,
     private val githubApiClient: GithubApiClient = GithubApiClient(),
     private val connectionUtility: ConnectionUtility = ConnectionUtility(),
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
 
     @Throws(IllegalStateException::class, UnknownHostException::class)
@@ -42,7 +40,7 @@ class AssetRepository(
             // Empty lists should not have propagated this deeply.
             if (list.isEmpty()) {
                 val err = IllegalStateException()
-                acraWrapper.logException(err)
+                logger.addExceptionBreadcrumb(err)
                 throw err
             }
             if (assetsArePresentInSupportDirectories(list)) {

--- a/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
@@ -17,7 +17,7 @@ class AppsStartupFsm(
     private val appsPreferences: AppsPreferences,
     private val filesystemUtility: FilesystemUtility,
     private val buildWrapper: BuildWrapper = BuildWrapper(),
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
 
     private val sessionDao = ulaDatabase.sessionDao()
@@ -48,8 +48,8 @@ class AppsStartupFsm(
     }
 
     fun submitEvent(event: AppsStartupEvent, coroutineScope: CoroutineScope) = coroutineScope.launch {
-        acraWrapper.putCustomString("Last submitted apps fsm event", "$event")
-        acraWrapper.putCustomString("State during apps fsm event submission", "${state.value}")
+        logger.addBreadcrumb("Last submitted apps fsm event", "$event")
+        logger.addBreadcrumb("State during apps fsm event submission", "${state.value}")
         if (!transitionIsAcceptable(event)) {
             state.postValue(IncorrectAppTransition(event, state.value!!))
             return@launch

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -21,7 +21,7 @@ class SessionStartupFsm(
     private val filesystemUtility: FilesystemUtility,
     private val downloadUtility: DownloadUtility,
     private val storageUtility: StorageUtility,
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
 
     private val state = MutableLiveData<SessionStartupState>().apply { postValue(WaitingForSessionSelection) }
@@ -92,8 +92,8 @@ class SessionStartupFsm(
     }
 
     fun submitEvent(event: SessionStartupEvent, coroutineScope: CoroutineScope) = coroutineScope.launch {
-        acraWrapper.putCustomString("Last submitted session fsm event", "$event")
-        acraWrapper.putCustomString("State during session fsm event submission", "${state.value}")
+        logger.addBreadcrumb("Last submitted session fsm event", "$event")
+        logger.addBreadcrumb("State during session fsm event submission", "${state.value}")
         if (!transitionIsAcceptable(event)) {
             state.postValue(IncorrectSessionTransition(event, state.value!!))
             return@launch

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -397,26 +397,6 @@ class LocalFileLocator(private val applicationFilesDir: String, private val reso
     }
 }
 
-class AcraWrapper {
-    fun putCustomString(key: String, value: String) {
-        ACRA.getErrorReporter().putCustomData(key, value)
-    }
-
-    fun logException(err: Exception): Exception {
-        val topOfStackTrace = err.stackTrace.first()
-        val key = "Exception: ${topOfStackTrace.fileName}"
-        val value = "${topOfStackTrace.lineNumber}"
-        ACRA.getErrorReporter().putCustomData(key, value)
-        return err
-    }
-
-    fun silentlySendIllegalStateReport(state: IllegalState) {
-        val type = state.javaClass.simpleName
-        putCustomString("State when sending silent report", type)
-        ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
-    }
-}
-
 class DeviceDimensions {
     private var width = 720
     private var height = 1480

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -17,11 +17,9 @@ import android.os.StatFs
 import androidx.core.content.ContextCompat
 import android.util.DisplayMetrics
 import android.view.WindowManager
-import org.acra.ACRA
 import tech.ula.R
 import tech.ula.model.entities.App
 import tech.ula.model.entities.Asset
-import tech.ula.viewmodel.IllegalState
 import java.io.File
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -266,7 +264,7 @@ class BuildWrapper {
                 }
         return if (supportedABIS.size == 1 && supportedABIS[0] == "") {
             val exception = IllegalStateException("No supported ABI!")
-            AcraWrapper().logException(exception)
+            SentryLogger().addExceptionBreadcrumb(exception)
             throw exception
         } else {
             supportedABIS[0]

--- a/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
+++ b/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
@@ -9,13 +9,13 @@ class AssetFileClearer(
     private val filesDir: File,
     private val assetDirectoryNames: Set<String>,
     private val busyboxExecutor: BusyboxExecutor,
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
     @Throws(Exception::class)
     suspend fun clearAllSupportAssets() {
         if (!filesDir.exists()) {
             val exception = FileNotFoundException()
-            acraWrapper.logException(exception)
+            logger.addExceptionBreadcrumb(exception)
             throw exception
         }
         clearFilesystemSupportAssets()
@@ -32,7 +32,7 @@ class AssetFileClearer(
             if (file.name == supportDirName) continue
             if (busyboxExecutor.recursivelyDelete(file.absolutePath) !is SuccessfulExecution) {
                 val exception = IOException()
-                acraWrapper.logException(exception)
+                logger.addExceptionBreadcrumb(exception)
                 throw exception
             }
         }
@@ -40,7 +40,7 @@ class AssetFileClearer(
         if (supportDir.exists()) {
             if (busyboxExecutor.recursivelyDelete(supportDir.absolutePath) !is SuccessfulExecution) {
                 val exception = IOException()
-                acraWrapper.logException(exception)
+                logger.addExceptionBreadcrumb(exception)
                 throw exception
             }
         }
@@ -60,7 +60,7 @@ class AssetFileClearer(
                 // Use deleteRecursively to match functionality above
                 if (busyboxExecutor.recursivelyDelete(supportFile.path) !is SuccessfulExecution) {
                     val exception = IOException()
-                    acraWrapper.logException(exception)
+                    logger.addExceptionBreadcrumb(exception)
                     throw exception
                 }
             }

--- a/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
+++ b/app/src/main/java/tech/ula/utils/FilesystemUtility.kt
@@ -10,7 +10,7 @@ import java.io.IOException
 class FilesystemUtility(
     private val applicationFilesDirPath: String,
     private val busyboxExecutor: BusyboxExecutor,
-    private val acraWrapper: AcraWrapper = AcraWrapper()
+    private val logger: Logger = SentryLogger()
 ) {
 
     private val filesystemExtractionSuccess = ".success_filesystem_extraction"
@@ -116,7 +116,7 @@ class FilesystemUtility(
         val result = busyboxExecutor.recursivelyDelete(filesystemDirectory.absolutePath)
         if (result is FailedExecution) {
             val err = IOException()
-            acraWrapper.logException(err)
+            logger.addExceptionBreadcrumb(err)
             throw err
         }
     }
@@ -134,7 +134,7 @@ class FilesystemUtility(
             appScriptSource.copyTo(appScriptProfileDTarget, overwrite = true)
         } catch (err: Exception) {
             val exception = IOException()
-            acraWrapper.logException(exception)
+            logger.addExceptionBreadcrumb(exception)
             throw exception
         }
     }

--- a/app/src/main/java/tech/ula/utils/Logger.kt
+++ b/app/src/main/java/tech/ula/utils/Logger.kt
@@ -1,0 +1,39 @@
+package tech.ula.utils
+
+import android.content.Context
+import io.sentry.Sentry
+import io.sentry.android.AndroidSentryClientFactory
+import io.sentry.event.BreadcrumbBuilder
+import io.sentry.event.Event
+import io.sentry.event.EventBuilder
+import tech.ula.viewmodel.IllegalState
+
+interface Logger {
+    fun initialize(context: Context? = null)
+
+    fun addBreadcrumb(key: String, value: String)
+
+    fun sendIllegalStateLog(state: IllegalState)
+}
+
+class SentryLogger : Logger {
+    override fun initialize(context: Context?) {
+        Sentry.init(AndroidSentryClientFactory(context!!))
+    }
+
+    override fun addBreadcrumb(key: String, value: String) {
+        val breadcrumb = BreadcrumbBuilder()
+                .setCategory(key)
+                .setMessage(value)
+                .build()
+        Sentry.getContext().recordBreadcrumb(breadcrumb)
+    }
+
+    override fun sendIllegalStateLog(state: IllegalState) {
+        val message = state.javaClass.simpleName
+        val event = EventBuilder()
+                .withMessage(message)
+                .withLevel(Event.Level.ERROR)
+        Sentry.capture(event)
+    }
+}

--- a/app/src/main/java/tech/ula/utils/Logger.kt
+++ b/app/src/main/java/tech/ula/utils/Logger.kt
@@ -32,11 +32,13 @@ class SentryLogger : Logger {
     }
 
     override fun addExceptionBreadcrumb(err: Exception) {
+        val stackTrace = err.stackTrace.first()
         val breadcrumb = BreadcrumbBuilder()
                 .setCategory("Exception")
                 .setData(mapOf(
                         "type" to err.javaClass.simpleName,
-                        "stackTrace" to err.stackTrace.toString()
+                        "file" to stackTrace.fileName,
+                        "lineNumber" to stackTrace.lineNumber.toString()
                 ))
                 .build()
         Sentry.getContext().recordBreadcrumb(breadcrumb)
@@ -50,3 +52,34 @@ class SentryLogger : Logger {
         Sentry.capture(event)
     }
 }
+
+//class AcraLogger : Logger {
+//    override fun initialize(context: Context?) {
+//        val builder = CoreConfigurationBuilder(context!!)
+//        builder.setBuildConfigClass(BuildConfig::class.java)
+//                .setReportFormat(StringFormat.JSON)
+//        builder.getPluginConfigurationBuilder(HttpSenderConfigurationBuilder::class.java)
+//                .setUri(BuildConfig.tracepotHttpsEndpoint)
+//                .setHttpMethod(HttpSender.Method.POST)
+//                .setEnabled(true)
+//        ACRA.init(context as Application, builder)
+//    }
+//
+//    override fun addBreadcrumb(key: String, value: String) {
+//        ACRA.getErrorReporter().putCustomData(key, value)
+//    }
+//
+//    override fun addExceptionBreadcrumb(err: Exception) {
+//        val topOfStackTrace = err.stackTrace.first()
+//        val key = "Exception: ${topOfStackTrace.fileName}"
+//        val value = "${topOfStackTrace.lineNumber}"
+//        ACRA.getErrorReporter().putCustomData(key, value)
+//        return err
+//    }
+//
+//    override fun sendIllegalStateLog(state: IllegalState) {
+//        val type = state.javaClass.simpleName
+//        addBreadcrumb("State when sending silent report", type)
+//        ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
+//    }
+//}

--- a/app/src/main/java/tech/ula/utils/Logger.kt
+++ b/app/src/main/java/tech/ula/utils/Logger.kt
@@ -53,7 +53,7 @@ class SentryLogger : Logger {
     }
 }
 
-//class AcraLogger : Logger {
+// class AcraLogger : Logger {
 //    override fun initialize(context: Context?) {
 //        val builder = CoreConfigurationBuilder(context!!)
 //        builder.setBuildConfigClass(BuildConfig::class.java)
@@ -82,4 +82,4 @@ class SentryLogger : Logger {
 //        addBreadcrumb("State when sending silent report", type)
 //        ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
 //    }
-//}
+// }

--- a/app/src/main/java/tech/ula/utils/Logger.kt
+++ b/app/src/main/java/tech/ula/utils/Logger.kt
@@ -39,7 +39,7 @@ class SentryLogger : Logger {
     }
 
     override fun addExceptionBreadcrumb(err: Exception) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
     }
 
     override fun sendIllegalStateLog(state: IllegalState) {

--- a/app/src/main/java/tech/ula/utils/Logger.kt
+++ b/app/src/main/java/tech/ula/utils/Logger.kt
@@ -1,17 +1,26 @@
 package tech.ula.utils
 
+import android.app.Application
 import android.content.Context
 import io.sentry.Sentry
 import io.sentry.android.AndroidSentryClientFactory
 import io.sentry.event.BreadcrumbBuilder
 import io.sentry.event.Event
 import io.sentry.event.EventBuilder
+import org.acra.ACRA
+import org.acra.config.CoreConfigurationBuilder
+import org.acra.config.HttpSenderConfigurationBuilder
+import org.acra.data.StringFormat
+import org.acra.sender.HttpSender
+import tech.ula.BuildConfig
 import tech.ula.viewmodel.IllegalState
 
 interface Logger {
     fun initialize(context: Context? = null)
 
     fun addBreadcrumb(key: String, value: String)
+
+    fun addExceptionBreadcrumb(err: Exception)
 
     fun sendIllegalStateLog(state: IllegalState)
 }
@@ -29,11 +38,46 @@ class SentryLogger : Logger {
         Sentry.getContext().recordBreadcrumb(breadcrumb)
     }
 
+    override fun addExceptionBreadcrumb(err: Exception) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
     override fun sendIllegalStateLog(state: IllegalState) {
         val message = state.javaClass.simpleName
         val event = EventBuilder()
                 .withMessage(message)
                 .withLevel(Event.Level.ERROR)
         Sentry.capture(event)
+    }
+}
+
+class AcraLogger : Logger {
+    override fun initialize(context: Context?) {
+        val builder = CoreConfigurationBuilder(context!!)
+        builder.setBuildConfigClass(BuildConfig::class.java)
+                .setReportFormat(StringFormat.JSON)
+        builder.getPluginConfigurationBuilder(HttpSenderConfigurationBuilder::class.java)
+                .setUri(BuildConfig.tracepotHttpsEndpoint)
+                .setHttpMethod(HttpSender.Method.POST)
+                .setEnabled(true)
+        ACRA.init(context as Application, builder)
+    }
+
+    override fun addBreadcrumb(key: String, value: String) {
+        ACRA.getErrorReporter().putCustomData(key, value)
+    }
+
+    override fun addExceptionBreadcrumb(err: Exception) {
+        val topOfStackTrace = err.stackTrace.first()
+        val key = "Exception: ${topOfStackTrace.fileName}"
+        val value = "${topOfStackTrace.lineNumber}"
+        ACRA.getErrorReporter().putCustomData(key, value)
+//        return err
+    }
+
+    override fun sendIllegalStateLog(state: IllegalState) {
+        val type = state.javaClass.simpleName
+        addBreadcrumb("State when sending silent report", type)
+        ACRA.getErrorReporter().handleSilentException(IllegalStateException(type))
     }
 }

--- a/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
+++ b/app/src/test/java/tech/ula/model/remote/GithubApiClientTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import tech.ula.utils.AcraWrapper
+import tech.ula.utils.Logger
 import tech.ula.utils.BuildWrapper
 import java.io.IOException
 
@@ -28,7 +28,7 @@ class GithubApiClientTest {
 
     @Mock lateinit var mockUrlProvider: UrlProvider
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     private val moshi = Moshi.Builder().build()
 
@@ -78,7 +78,7 @@ class GithubApiClientTest {
     fun setup() {
         whenever(mockBuildWrapper.getArchType()).thenReturn(testArch)
 
-        githubApiClient = GithubApiClient(mockBuildWrapper, mockUrlProvider, mockAcraWrapper)
+        githubApiClient = GithubApiClient(mockBuildWrapper, mockUrlProvider, mockLogger)
     }
 
     @After
@@ -142,7 +142,7 @@ class GithubApiClientTest {
 
         runBlocking { githubApiClient.getAssetsListDownloadUrl(testRepo) }
 
-        verify(mockAcraWrapper.logException(IOException()))
+        verify(mockLogger.addExceptionBreadcrumb(IOException()))
     }
 
     @Test
@@ -185,7 +185,7 @@ class GithubApiClientTest {
 
         runBlocking { githubApiClient.getLatestReleaseVersion(testRepo) }
 
-        verify(mockAcraWrapper.logException(IOException()))
+        verify(mockLogger.addExceptionBreadcrumb(IOException()))
     }
 
     @Test
@@ -228,7 +228,7 @@ class GithubApiClientTest {
 
         runBlocking { githubApiClient.getAssetEndpoint(testAssetType, testRepo) }
 
-        verify(mockAcraWrapper).logException(IOException())
+        verify(mockLogger).addExceptionBreadcrumb(IOException())
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
+++ b/app/src/test/java/tech/ula/model/repositories/AssetRepositoryTest.kt
@@ -13,7 +13,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import tech.ula.model.entities.Asset
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.remote.GithubApiClient
-import tech.ula.utils.AcraWrapper
+import tech.ula.utils.Logger
 import tech.ula.utils.AssetPreferences
 import tech.ula.utils.ConnectionUtility
 import java.io.File
@@ -34,7 +34,7 @@ class AssetRepositoryTest {
 
     @Mock lateinit var mockConnectionUtility: ConnectionUtility
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     private lateinit var assetRepository: AssetRepository
 
@@ -102,7 +102,7 @@ class AssetRepositoryTest {
     fun setup() {
         applicationFilesDirPath = tempFolder.root.absolutePath
 
-        assetRepository = AssetRepository(applicationFilesDirPath, mockAssetPreferences, mockGithubApiClient, mockConnectionUtility, mockAcraWrapper)
+        assetRepository = AssetRepository(applicationFilesDirPath, mockAssetPreferences, mockGithubApiClient, mockConnectionUtility, mockLogger)
     }
 
     @Test(expected = IllegalStateException::class)
@@ -113,7 +113,7 @@ class AssetRepositoryTest {
             assetRepository.generateDownloadRequirements(filesystem, assetLists, true)
         }
 
-        verify(mockAcraWrapper).logException(IOException())
+        verify(mockLogger).addExceptionBreadcrumb(IOException())
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/AppsStartupFsmTest.kt
@@ -42,7 +42,7 @@ class AppsStartupFsmTest {
 
     @Mock lateinit var mockBuildWrapper: BuildWrapper
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     @Mock lateinit var mockStateObserver: Observer<AppsStartupState>
 
@@ -95,7 +95,7 @@ class AppsStartupFsmTest {
         whenever(mockUlaDatabase.filesystemDao()).thenReturn(mockFilesystemDao)
         whenever(mockUlaDatabase.sessionDao()).thenReturn(mockSessionDao)
 
-        appsFsm = AppsStartupFsm(mockUlaDatabase, mockAppsPreferences, mockFilesystemUtility, mockBuildWrapper, mockAcraWrapper)
+        appsFsm = AppsStartupFsm(mockUlaDatabase, mockAppsPreferences, mockFilesystemUtility, mockBuildWrapper, mockLogger)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
+++ b/app/src/test/java/tech/ula/model/state/SessionStartupFsmTest.kt
@@ -46,7 +46,7 @@ class SessionStartupFsmTest {
 
     @Mock lateinit var mockStateObserver: Observer<SessionStartupState>
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     @Mock lateinit var mockStorageUtility: StorageUtility
 
@@ -119,7 +119,7 @@ class SessionStartupFsmTest {
         whenever(mockUlaDatabase.filesystemDao()).thenReturn(mockFilesystemDao)
         whenever(mockFilesystemDao.getAllFilesystems()).thenReturn(filesystemLiveData)
 
-        sessionFsm = SessionStartupFsm(mockUlaDatabase, mockAssetRepository, mockFilesystemUtility, mockDownloadUtility, mockStorageUtility, mockAcraWrapper)
+        sessionFsm = SessionStartupFsm(mockUlaDatabase, mockAssetRepository, mockFilesystemUtility, mockDownloadUtility, mockStorageUtility, mockLogger)
     }
 
     @After

--- a/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
@@ -23,7 +23,7 @@ class AssetFileClearerTest {
 
     @Mock lateinit var busyboxExecutor: BusyboxExecutor
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     lateinit var filesDir: File
     lateinit var supportDir: File
@@ -52,7 +52,7 @@ class AssetFileClearerTest {
     fun setup() {
         createTestFiles()
 
-        assetFileClearer = AssetFileClearer(filesDir, assetDirectoryNames, busyboxExecutor, mockAcraWrapper)
+        assetFileClearer = AssetFileClearer(filesDir, assetDirectoryNames, busyboxExecutor, mockLogger)
     }
 
     fun createTestFiles() {
@@ -82,7 +82,7 @@ class AssetFileClearerTest {
 
         runBlocking { assetFileClearer.clearAllSupportAssets() }
 
-        verify(mockAcraWrapper.logException(FileNotFoundException()))
+        verify(mockLogger.addExceptionBreadcrumb(FileNotFoundException()))
     }
 
     @Test

--- a/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/FilesystemUtilityTest.kt
@@ -24,7 +24,7 @@ class FilesystemUtilityTest {
 
     @Mock lateinit var mockBusyboxExecutor: BusyboxExecutor
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     private val statelessListener: (line: String) -> Unit = { }
 
@@ -36,7 +36,7 @@ class FilesystemUtilityTest {
     @Before
     fun setup() {
         applicationFilesDirPath = tempFolder.root.path
-        filesystemUtility = FilesystemUtility(applicationFilesDirPath, mockBusyboxExecutor, mockAcraWrapper)
+        filesystemUtility = FilesystemUtility(applicationFilesDirPath, mockBusyboxExecutor, mockLogger)
     }
 
     @Test
@@ -363,7 +363,7 @@ class FilesystemUtilityTest {
             filesystemUtility.deleteFilesystem(100)
         }
         verifyBlocking(mockBusyboxExecutor) { recursivelyDelete(testDir.absolutePath) }
-        verify(mockAcraWrapper).logException(IOException())
+        verify(mockLogger).addExceptionBreadcrumb(IOException())
     }
 
     @Test
@@ -397,6 +397,6 @@ class FilesystemUtilityTest {
 
         filesystemUtility.moveAppScriptToRequiredLocation(sourceAppName, filesystem)
 
-        verify(mockAcraWrapper).logException(IOException())
+        verify(mockLogger).addExceptionBreadcrumb(IOException())
     }
 }

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -31,7 +31,7 @@ class MainActivityViewModelTest {
 
     @Mock lateinit var mockAssetFileClearer: AssetFileClearer
 
-    @Mock lateinit var mockAcraWrapper: AcraWrapper
+    @Mock lateinit var mockLogger: Logger
 
     @Mock lateinit var mockStateObserver: Observer<State>
 
@@ -77,7 +77,7 @@ class MainActivityViewModelTest {
         whenever(mockSessionStartupFsm.getState()).thenReturn(sessionStartupStateLiveData)
         sessionStartupStateLiveData.postValue(WaitingForSessionSelection)
 
-        mainActivityViewModel = MainActivityViewModel(mockAppsStartupFsm, mockSessionStartupFsm, mockAcraWrapper)
+        mainActivityViewModel = MainActivityViewModel(mockAppsStartupFsm, mockSessionStartupFsm, mockLogger)
         mainActivityViewModel.getState().observeForever(mockStateObserver)
     }
 
@@ -117,7 +117,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.permissionsHaveBeenGranted()
 
         verify(mockStateObserver).onChanged(TooManySelectionsMadeWhenPermissionsGranted)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(TooManySelectionsMadeWhenPermissionsGranted)
+        verify(mockLogger).sendIllegalStateLog(TooManySelectionsMadeWhenPermissionsGranted)
     }
 
     @Test
@@ -126,7 +126,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.permissionsHaveBeenGranted()
 
         verify(mockStateObserver).onChanged(NoSelectionsMadeWhenPermissionsGranted)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSelectionsMadeWhenPermissionsGranted)
+        verify(mockLogger).sendIllegalStateLog(NoSelectionsMadeWhenPermissionsGranted)
     }
 
     @Test
@@ -189,7 +189,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitFilesystemCredentials("", "", "")
 
         verify(mockStateObserver).onChanged(NoFilesystemSelectedWhenCredentialsSubmitted)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoFilesystemSelectedWhenCredentialsSubmitted)
+        verify(mockLogger).sendIllegalStateLog(NoFilesystemSelectedWhenCredentialsSubmitted)
     }
 
     @Test
@@ -211,7 +211,7 @@ class MainActivityViewModelTest {
         mainActivityViewModel.submitAppServicePreference(SshTypePreference)
 
         verify(mockStateObserver).onChanged(NoAppSelectedWhenPreferenceSubmitted)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoAppSelectedWhenPreferenceSubmitted)
+        verify(mockLogger).sendIllegalStateLog(NoAppSelectedWhenPreferenceSubmitted)
     }
 
     @Test
@@ -286,7 +286,7 @@ class MainActivityViewModelTest {
         verify(mockAssetFileClearer).clearAllSupportAssets()
         verify(mockStateObserver).onChanged(ClearingSupportFiles)
         verify(mockStateObserver).onChanged(FailedToClearSupportFiles)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(FailedToClearSupportFiles)
+        verify(mockLogger).sendIllegalStateLog(FailedToClearSupportFiles)
     }
 
     // Private function tests.
@@ -310,7 +310,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(DatabaseEntriesFetchFailed)
 
         verify(mockStateObserver).onChanged(NoAppSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoAppSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoAppSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -324,7 +324,7 @@ class MainActivityViewModelTest {
 
         val expectedState = IllegalStateTransition("$badTransition")
         verify(mockStateObserver).onChanged(expectedState)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(expectedState)
+        verify(mockLogger).sendIllegalStateLog(expectedState)
     }
 
     @Test
@@ -348,7 +348,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(DatabaseEntriesFetchFailed)
 
         verify(mockStateObserver).onChanged(ErrorFetchingAppDatabaseEntries)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(ErrorFetchingAppDatabaseEntries)
+        verify(mockLogger).sendIllegalStateLog(ErrorFetchingAppDatabaseEntries)
     }
 
     @Test
@@ -409,7 +409,7 @@ class MainActivityViewModelTest {
         appsStartupStateLiveData.postValue(AppScriptCopyFailed)
 
         verify(mockStateObserver).onChanged(ErrorCopyingAppScript)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(ErrorCopyingAppScript)
+        verify(mockLogger).sendIllegalStateLog(ErrorCopyingAppScript)
     }
 
     @Test
@@ -433,7 +433,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(NoDownloadsRequired)
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -447,7 +447,7 @@ class MainActivityViewModelTest {
 
         val expectedState = IllegalStateTransition("$badTransition")
         verify(mockStateObserver).onChanged(expectedState)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(expectedState)
+        verify(mockLogger).sendIllegalStateLog(expectedState)
     }
 
     @Test
@@ -473,7 +473,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(SessionIsReadyForPreparation(unselectedSession, unselectedFilesystem))
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -503,7 +503,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AssetListsRetrievalSucceeded(assetList))
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -524,7 +524,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AssetListsRetrievalFailed)
 
         verify(mockStateObserver).onChanged(ErrorFetchingAssetLists)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(ErrorFetchingAssetLists)
+        verify(mockLogger).sendIllegalStateLog(ErrorFetchingAssetLists)
     }
 
     @Test
@@ -561,7 +561,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(NoDownloadsRequired)
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -601,7 +601,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(DownloadsHaveFailed(reason))
 
         verify(mockStateObserver).onChanged(DownloadsDidNotCompleteSuccessfully(reason))
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(DownloadsDidNotCompleteSuccessfully(reason))
+        verify(mockLogger).sendIllegalStateLog(DownloadsDidNotCompleteSuccessfully(reason))
     }
 
     @Test
@@ -609,7 +609,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AttemptedCacheAccessWhileEmpty)
 
         verify(mockStateObserver).onChanged(DownloadCacheAccessedWhileEmpty)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(DownloadCacheAccessedWhileEmpty)
+        verify(mockLogger).sendIllegalStateLog(DownloadCacheAccessedWhileEmpty)
     }
 
     @Test
@@ -617,7 +617,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(AttemptedCacheAccessInIncorrectState)
 
         verify(mockStateObserver).onChanged(DownloadCacheAccessedInAnIncorrectState)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(DownloadCacheAccessedInAnIncorrectState)
+        verify(mockLogger).sendIllegalStateLog(DownloadCacheAccessedInAnIncorrectState)
     }
 
     @Test
@@ -657,7 +657,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(LocalDirectoryCopyFailed)
 
         verify(mockStateObserver).onChanged(FailedToCopyAssetsToLocalStorage)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(FailedToCopyAssetsToLocalStorage)
+        verify(mockLogger).sendIllegalStateLog(FailedToCopyAssetsToLocalStorage)
     }
 
     @Test
@@ -674,7 +674,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(FilesystemAssetVerificationSucceeded)
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -715,7 +715,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(FilesystemAssetCopyFailed)
 
         verify(mockStateObserver).onChanged(FailedToCopyAssetsToFilesystem)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(FailedToCopyAssetsToFilesystem)
+        verify(mockLogger).sendIllegalStateLog(FailedToCopyAssetsToFilesystem)
     }
 
     @Test
@@ -733,7 +733,7 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(ExtractionHasCompletedSuccessfully)
 
         verify(mockStateObserver).onChanged(NoSessionSelectedWhenTransitionNecessary)
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(NoSessionSelectedWhenTransitionNecessary)
+        verify(mockLogger).sendIllegalStateLog(NoSessionSelectedWhenTransitionNecessary)
     }
 
     @Test
@@ -759,6 +759,6 @@ class MainActivityViewModelTest {
         sessionStartupStateLiveData.postValue(ExtractionFailed("reason"))
 
         verify(mockStateObserver).onChanged(FailedToExtractFilesystem("reason"))
-        verify(mockAcraWrapper).silentlySendIllegalStateReport(FailedToExtractFilesystem("reason"))
+        verify(mockLogger).sendIllegalStateLog(FailedToExtractFilesystem("reason"))
     }
 }


### PR DESCRIPTION
**Describe the pull request**

Tracepot as a crash collection tool has repeatedly been found lacking. This PR replaces ACRA/Tracepot with Sentry, another crash logging tool that seems much better suited for our use case.

**Link to relevant issues**
N/A