### PR TITLE
Update Proot Debug Logging for Android Q.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
-    private val prootDebugLogger = ProotDebugLogger(DefaultPreferences(this.defaultSharedPreferences), this.storageRoot.path)
+    private val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
     private val busyboxExecutor = BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), prootDebugLogger)
 
     private val navController: NavController by lazy {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -66,8 +66,10 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
-    private val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
-    private val busyboxExecutor = BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), prootDebugLogger)
+    private val busyboxExecutor by lazy {
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
+        BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), prootDebugLogger)
+    }
 
     private val navController: NavController by lazy {
         findNavController(R.id.nav_host_fragment)

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -66,6 +66,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
+    private val prootDebugLogger = ProotDebugLogger(DefaultPreferences(this.defaultSharedPreferences), this.storageRoot.path)
+    private val busyboxExecutor = BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), prootDebugLogger)
 
     private val navController: NavController by lazy {
         findNavController(R.id.nav_host_fragment)
@@ -114,7 +116,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         val assetPreferences = AssetPreferences(this.getSharedPreferences("assetLists", Context.MODE_PRIVATE))
         val assetRepository = AssetRepository(filesDir.path, assetPreferences)
 
-        val busyboxExecutor = BusyboxExecutor(filesDir, Environment.getExternalStorageDirectory(), DefaultPreferences(defaultSharedPreferences))
         val filesystemUtility = FilesystemUtility(filesDir.path, busyboxExecutor)
         val storageUtility = StorageUtility(StatFs(Environment.getExternalStorageDirectory().path))
 
@@ -447,7 +448,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
     private fun handleClearSupportFiles() {
         val appsPreferences = AppsPreferences(this.getSharedPreferences("apps", Context.MODE_PRIVATE))
-        val busyboxExecutor = BusyboxExecutor(this.filesDir, Environment.getExternalStorageDirectory(), DefaultPreferences(defaultSharedPreferences))
         val assetDirectoryNames = appsPreferences.getDistributionsList().plus("support")
         val assetFileClearer = AssetFileClearer(this.filesDir, assetDirectoryNames, busyboxExecutor)
         CoroutineScope(Dispatchers.Main).launch { viewModel.handleClearSupportFiles(assetFileClearer) }

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -32,7 +32,7 @@ class ServerService : Service() {
 
     private val busyboxExecutor by lazy {
         val externalStorage = Environment.getExternalStorageDirectory()
-        val prootDebugLogger = ProotDebugLogger(DefaultPreferences(this.defaultSharedPreferences), this.storageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
         BusyboxExecutor(this.filesDir, externalStorage, prootDebugLogger)
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -32,7 +32,8 @@ class ServerService : Service() {
 
     private val busyboxExecutor by lazy {
         val externalStorage = Environment.getExternalStorageDirectory()
-        BusyboxExecutor(this.filesDir, externalStorage, DefaultPreferences(this.defaultSharedPreferences))
+        val prootDebugLogger = ProotDebugLogger(DefaultPreferences(this.defaultSharedPreferences), this.storageRoot.path)
+        BusyboxExecutor(this.filesDir, externalStorage, prootDebugLogger)
     }
 
     private val filesystemUtility by lazy {

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -20,7 +20,7 @@ import tech.ula.model.entities.Filesystem
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 import tech.ula.model.entities.Session
-import tech.ula.utils.*
+import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import tech.ula.viewmodel.FilesystemListViewModel
 
 class FilesystemListFragment : Fragment() {

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -18,12 +18,9 @@ import tech.ula.R
 import tech.ula.ServerService
 import tech.ula.model.entities.Filesystem
 import tech.ula.model.repositories.UlaDatabase
-import tech.ula.utils.BusyboxExecutor
-import tech.ula.utils.DefaultPreferences
-import tech.ula.utils.FilesystemUtility
 import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 import tech.ula.model.entities.Session
-import tech.ula.utils.defaultSharedPreferences
+import tech.ula.utils.*
 import tech.ula.viewmodel.FilesystemListViewModel
 
 class FilesystemListFragment : Fragment() {
@@ -44,7 +41,8 @@ class FilesystemListFragment : Fragment() {
     private val filesystemListViewModel: FilesystemListViewModel by lazy {
         val filesystemDao = UlaDatabase.getInstance(activityContext).filesystemDao()
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
-        val busyboxExecutor = BusyboxExecutor(activityContext.filesDir, externalStorageDir, DefaultPreferences(activityContext.defaultSharedPreferences))
+        val prootDebugLogger = ProotDebugLogger(DefaultPreferences(activityContext.defaultSharedPreferences), activityContext.storageRoot.path)
+        val busyboxExecutor = BusyboxExecutor(activityContext.filesDir, externalStorageDir, prootDebugLogger)
         val filesystemUtility = FilesystemUtility(activityContext.filesDir.absolutePath, busyboxExecutor)
         ViewModelProviders.of(this, FilesystemListViewmodelFactory(filesystemDao, sessionDao, filesystemUtility)).get(FilesystemListViewModel::class.java)
     }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -41,7 +41,7 @@ class FilesystemListFragment : Fragment() {
     private val filesystemListViewModel: FilesystemListViewModel by lazy {
         val filesystemDao = UlaDatabase.getInstance(activityContext).filesystemDao()
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
-        val prootDebugLogger = ProotDebugLogger(DefaultPreferences(activityContext.defaultSharedPreferences), activityContext.storageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, activityContext.storageRoot.path)
         val busyboxExecutor = BusyboxExecutor(activityContext.filesDir, externalStorageDir, prootDebugLogger)
         val filesystemUtility = FilesystemUtility(activityContext.filesDir.absolutePath, busyboxExecutor)
         ViewModelProviders.of(this, FilesystemListViewmodelFactory(filesystemDao, sessionDao, filesystemUtility)).get(FilesystemListViewModel::class.java)

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -66,7 +66,6 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
                     else Toast.makeText(activity, R.string.debug_log_export_failure, Toast.LENGTH_LONG).show()
                 }
             }
-
         }
     }
 

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -1,25 +1,39 @@
 package tech.ula.ui
 
+import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.os.Environment
 import tech.ula.R
-import java.io.File
 import androidx.preference.PreferenceFragmentCompat
 import android.widget.Toast
 import androidx.preference.Preference
+import tech.ula.utils.ProotDebugLogger
+import tech.ula.utils.defaultSharedPreferences
+import tech.ula.utils.storageRoot
+
+private const val EXPORT_REQUEST_CODE = 42
 
 class SettingsFragment : PreferenceFragmentCompat() {
+
+    private val prootDebugLogger by lazy {
+        ProotDebugLogger(activity!!.defaultSharedPreferences, activity!!.storageRoot.path)
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences)
 
+        val exportFilePreference: Preference = findPreference("pref_proot_export_debug_file")!!
+        exportFilePreference.setOnPreferenceClickListener {
+            val intent = prootDebugLogger.generateCreateIntent()
+            startActivityForResult(intent, EXPORT_REQUEST_CODE)
+            true
+        }
+
         val deleteFilePreference: Preference = findPreference("pref_proot_delete_debug_file")!!
         deleteFilePreference.setOnPreferenceClickListener {
-            val debugFile = File("${Environment.getExternalStorageDirectory()}/PRoot_Debug_Log")
-            if (debugFile.exists()) debugFile.delete()
+            prootDebugLogger.deleteLog()
             Toast.makeText(activity, R.string.debug_log_deleted, Toast.LENGTH_LONG).show()
             true
         }
@@ -31,5 +45,15 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     override fun setDividerHeight(height: Int) {
         super.setDividerHeight(0)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == EXPORT_REQUEST_CODE) {
+            data?.data?.let {
+                prootDebugLogger.copyLogToDestination(it, activity!!.contentResolver)
+            }
+
+        }
     }
 }

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -62,8 +62,8 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
             data?.data?.let {
                 launch {
                     val result = prootDebugLogger.copyLogToDestination(it, activity!!.contentResolver)
-                    if (result) Toast.makeText(activity, "success", Toast.LENGTH_LONG).show()
-                    else Toast.makeText(activity, "failure", Toast.LENGTH_LONG).show()
+                    if (result) Toast.makeText(activity, R.string.debug_log_export_success, Toast.LENGTH_LONG).show()
+                    else Toast.makeText(activity, R.string.debug_log_export_failure, Toast.LENGTH_LONG).show()
                 }
             }
 

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -94,21 +94,6 @@ class StorageUtility(private val statFs: StatFs) {
     }
 }
 
-class DefaultPreferences(private val prefs: SharedPreferences) {
-
-    fun getProotDebuggingEnabled(): Boolean {
-        return prefs.getBoolean("pref_proot_debug_enabled", false)
-    }
-
-    fun getProotDebuggingLevel(): String {
-        return prefs.getString("pref_proot_debug_level", "-1") ?: ""
-    }
-
-    fun getProotDebugLogLocation(): String {
-        return prefs.getString("pref_proot_debug_log_location", "${Environment.getExternalStorageDirectory().path}/PRoot_Debug_Log") ?: ""
-    }
-}
-
 class AssetPreferences(private val prefs: SharedPreferences) {
 
     private val versionString = "version"

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -2,11 +2,9 @@ package tech.ula.utils
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
-import kotlin.text.Charsets.UTF_8
 
 sealed class ExecutionResult
 data class MissingExecutionAsset(val asset: String) : ExecutionResult()

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -17,7 +17,7 @@ data class OngoingExecution(val process: Process) : ExecutionResult()
 class BusyboxExecutor(
     private val filesDir: File,
     private val externalStorageDir: File,
-    private val defaultPreferences: DefaultPreferences,
+    private val prootDebugLogger: ProotDebugLogger,
     private val busyboxWrapper: BusyboxWrapper = BusyboxWrapper()
 ) {
 
@@ -60,10 +60,9 @@ class BusyboxExecutor(
             !busyboxWrapper.executionScriptIsPresent(filesDir) -> return MissingExecutionAsset("execution script")
         }
 
-        val prootDebugEnabled = defaultPreferences.getProotDebuggingEnabled()
+        val prootDebugEnabled = prootDebugLogger.isEnabled
         val prootDebugLevel =
-                if (prootDebugEnabled) defaultPreferences.getProotDebuggingLevel() else "-1"
-        val prootDebugLocation = defaultPreferences.getProotDebugLogLocation()
+                if (prootDebugEnabled) prootDebugLogger.verbosityLevel else "-1"
 
         val updatedCommand = busyboxWrapper.addBusyboxAndProot(command)
         val filesystemDir = File("${filesDir.absolutePath}/$filesystemDirName")
@@ -79,11 +78,11 @@ class BusyboxExecutor(
             val process = processBuilder.start()
             when {
                 prootDebugEnabled && commandShouldTerminate -> {
-                    redirectOutputToDebugLog(process.inputStream, prootDebugLocation, coroutineScope)
+                    prootDebugLogger.logStream(process.inputStream, coroutineScope)
                     getProcessResult(process)
                 }
                 prootDebugEnabled && !commandShouldTerminate -> {
-                    redirectOutputToDebugLog(process.inputStream, prootDebugLocation, coroutineScope)
+                    prootDebugLogger.logStream(process.inputStream, coroutineScope)
                     OngoingExecution(process)
                 }
                 commandShouldTerminate -> {
@@ -110,24 +109,6 @@ class BusyboxExecutor(
         buf.forEachLine { listener(it) }
 
         buf.close()
-    }
-
-    private fun redirectOutputToDebugLog(
-        inputStream: InputStream,
-        prootDebugLocation: String,
-        coroutineScope: CoroutineScope
-    ) = coroutineScope.launch {
-        val prootLogFile = File(prootDebugLocation)
-        if (prootLogFile.exists()) {
-            prootLogFile.delete()
-        }
-        prootLogFile.createNewFile()
-        val reader = inputStream.bufferedReader(UTF_8)
-        val writer = prootLogFile.writer(UTF_8)
-        reader.forEachLine { line -> writer.write("$line\n") }
-        reader.close()
-        writer.flush()
-        writer.close()
     }
 
     private fun getProcessResult(process: Process): ExecutionResult {

--- a/app/src/main/java/tech/ula/utils/Extensions.kt
+++ b/app/src/main/java/tech/ula/utils/Extensions.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.annotation.IdRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import java.io.File
 
 fun <A, B> zipLiveData(a: LiveData<A>, b: LiveData<B>): LiveData<Pair<A, B>> {
     return MediatorLiveData<Pair<A, B>>().apply {
@@ -31,6 +32,13 @@ fun <A, B> zipLiveData(a: LiveData<A>, b: LiveData<B>): LiveData<Pair<A, B>> {
         }
     }
 }
+
+inline val Context.storageRoot: File
+    get() = this.getExternalFilesDir(null) ?: run {
+        val storageRoot = File(this.filesDir, "storage")
+        storageRoot.mkdirs()
+        storageRoot
+    }
 
 inline val Context.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(this)

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -1,13 +1,19 @@
 package tech.ula.utils
 
+import android.content.SharedPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.InputStream
 
-class ProotDebugLogger(defaultPreferences: DefaultPreferences, storageRootPath: String) {
-    val isEnabled = defaultPreferences.getProotDebuggingEnabled()
-    val verbosityLevel = defaultPreferences.getProotDebuggingLevel()
+class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootPath: String) {
+    private val prefs = defaultSharedPreferences
+
+    val isEnabled: Boolean
+        get() = prefs.getBoolean("pref_proot_debug_enabled", false)
+
+    val verbosityLevel
+        get() = prefs.getString("pref_proot_debug_level", "-1") ?: ""
 
     private val logLocation = "$storageRootPath/Proot_Debug_Log.txt"
 

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -19,7 +19,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootP
     val verbosityLevel
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
-    val logName = "PRoot_Debug_Log.txt"
+    val logName = "Proot_Debug_Log.txt"
     private val logLocation = "$storageRootPath/$logName"
 
     fun logStream(

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -1,0 +1,30 @@
+package tech.ula.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.InputStream
+
+class ProotDebugLogger(defaultPreferences: DefaultPreferences, storageRootPath: String) {
+    val isEnabled = defaultPreferences.getProotDebuggingEnabled()
+    val verbosityLevel = defaultPreferences.getProotDebuggingLevel()
+
+    private val logLocation = "$storageRootPath/Proot_Debug_Log.txt"
+
+    fun logStream(
+            inputStream: InputStream,
+            coroutineScope: CoroutineScope
+    ) = coroutineScope.launch {
+        val prootLogFile = File(logLocation)
+        if (prootLogFile.exists()) {
+            prootLogFile.delete()
+        }
+        prootLogFile.createNewFile()
+        val reader = inputStream.bufferedReader(Charsets.UTF_8)
+        val writer = prootLogFile.writer(Charsets.UTF_8)
+        reader.forEachLine { line -> writer.write("$line\n") }
+        reader.close()
+        writer.flush()
+        writer.close()
+    }
+}

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -1,17 +1,13 @@
 package tech.ula.utils
 
 import android.content.ContentResolver
-import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
-import androidx.core.net.toFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileOutputStream
 import java.io.InputStream
 
 class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootPath: String) {
@@ -27,8 +23,8 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootP
     private val logLocation = "$storageRootPath/$logName"
 
     fun logStream(
-            inputStream: InputStream,
-            coroutineScope: CoroutineScope
+        inputStream: InputStream,
+        coroutineScope: CoroutineScope
     ) = coroutineScope.launch {
         val prootLogFile = File(logLocation)
         if (prootLogFile.exists()) {
@@ -45,7 +41,6 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootP
 
     suspend fun copyLogToDestination(uri: Uri, contentResolver: ContentResolver): Boolean = withContext(Dispatchers.IO) {
         val logFile = File(logLocation)
-        if (!logFile.exists()) return@withContext false
         try {
             contentResolver.openOutputStream(uri, "w")?.use { outputStream ->
                     outputStream.write(logFile.readText().toByteArray())

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -13,7 +13,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootP
         get() = prefs.getBoolean("pref_proot_debug_enabled", false)
 
     val verbosityLevel
-        get() = prefs.getString("pref_proot_debug_level", "-1") ?: ""
+        get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
     private val logLocation = "$storageRootPath/Proot_Debug_Log.txt"
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="pref_proot_debugging_level_title">Debug Verbosity Level</string>
     <string name="pref_proot_debugging_level_summary">The higher the number, the greater the verbosity.</string>
     <string name="pref_proot_debugging_level_default">-1</string>
+    <string name="pref_proot_export_debug_file_title">Export Debug File</string>
     <string name="pref_proot_delete_debug_file_title">Delete Debug File</string>
 
     <!-- Help Activity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,7 +228,9 @@
     <string name="filesystem_unique_name_required">Filesystems require a unique name!</string>
     <string name="single_session_supported">UserLAnd currently only supports a single active session!</string>
     <string name="no_supported_architecture">UserLAnd does not currently support your devices architecture.</string>
-    <string name="debug_log_deleted">Debug log deleted or does not exist!</string>
+    <string name="debug_log_export_success">Debug log exported successfully!</string>
+    <string name="debug_log_export_failure">Exporting debug log failed!</string>
+    <string name="debug_log_deleted">Debug log deleted!</string>
 
     <!-- Content descriptions -->
     <string name="desc_arrow">Image: Arrow denoting connection between session and filesystem.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -35,6 +35,11 @@
             app:iconSpaceReserved="false"/>
         <Preference
             android:dependency="pref_proot_debug_enabled"
+            android:key="pref_proot_export_debug_file"
+            android:title="@string/pref_proot_export_debug_file_title"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:dependency="pref_proot_debug_enabled"
             android:key="pref_proot_delete_debug_file"
             android:title="@string/pref_proot_delete_debug_file_title"
             app:iconSpaceReserved="false"/>

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -1,7 +1,11 @@
 package tech.ula.utils
 
+import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
+import androidx.core.net.toUri
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
@@ -20,6 +24,10 @@ class ProotDebugLoggerTest {
     @get:Rule val tempFolder = TemporaryFolder()
 
     @Mock lateinit var mockDefaultSharedPreferences: SharedPreferences
+
+    @Mock lateinit var mockContentResolver: ContentResolver
+
+    @Mock lateinit var mockUri: Uri
 
     private val logName = "Proot_Debug_Log.txt"
 
@@ -75,5 +83,21 @@ class ProotDebugLoggerTest {
 
         val logText = logFile.readText().trim()
         assertEquals(originalText, logText)
+    }
+
+    @Test
+    fun `Copies log to a URI-specified destination`() {
+        val originalText = "copy world"
+        val logFile = File(tempFolder.root, logName)
+        logFile.writeText(originalText)
+
+        val destinationFile = File(tempFolder.root, "destination")
+
+        whenever(mockContentResolver.openOutputStream(mockUri, "w"))
+                .thenReturn(destinationFile.outputStream())
+
+        runBlocking { prootDebugLogger.copyLogToDestination(mockUri, mockContentResolver) }
+
+        assertEquals(originalText, destinationFile.readText().trim())
     }
 }

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -3,6 +3,7 @@ package tech.ula.utils
 import android.content.Context
 import android.content.SharedPreferences
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -11,6 +12,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
 
 @RunWith(MockitoJUnitRunner::class)
 class ProotDebugLoggerTest {
@@ -18,6 +20,8 @@ class ProotDebugLoggerTest {
     @get:Rule val tempFolder = TemporaryFolder()
 
     @Mock lateinit var mockDefaultSharedPreferences: SharedPreferences
+
+    private val logName = "Proot_Debug_Log.txt"
 
     private lateinit var prootDebugLogger: ProotDebugLogger
 
@@ -32,5 +36,44 @@ class ProotDebugLoggerTest {
                 .thenReturn(true)
 
         assertTrue(prootDebugLogger.isEnabled)
+    }
+
+    @Test
+    fun `Property verbosityLevel fetches from cache`() {
+        val level = "500"
+        whenever(mockDefaultSharedPreferences.getString("pref_proot_debug_level", "-1"))
+                .thenReturn(level)
+
+        assertEquals(level, prootDebugLogger.verbosityLevel)
+    }
+
+    @Test
+    fun `Creates new log`() {
+        val originalText = "hello world"
+        val outputFile = File(tempFolder.root, "test")
+        val logFile = File(tempFolder.root, logName)
+
+        outputFile.writeText(originalText)
+        assertFalse(logFile.exists())
+
+        runBlocking { prootDebugLogger.logStream(outputFile.inputStream(), this) }
+
+        val logText = logFile.readText().trim()
+        assertEquals(originalText, logText)
+    }
+
+    @Test
+    fun `Overwrites original log`() {
+        val originalText = "hello world"
+        val outputFile = File(tempFolder.root, "test")
+        val logFile = File(tempFolder.root, logName)
+
+        outputFile.writeText(originalText)
+        logFile.writeText("world hello")
+
+        runBlocking { prootDebugLogger.logStream(outputFile.inputStream(), this) }
+
+        val logText = logFile.readText().trim()
+        assertEquals(originalText, logText)
     }
 }

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -1,14 +1,11 @@
 package tech.ula.utils
 
 import android.content.ContentResolver
-import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
-import androidx.core.net.toUri
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
+import org.junit.Assert.* // ktlint-disable no-wildcard-imports
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -104,7 +101,7 @@ class ProotDebugLoggerTest {
     }
 
     @Test
-    fun `copyLogToDestination returns false on failure`() {
+    fun `copyLogToDestination returns false on failure if log file does not exist`() {
         val destinationFile = File(tempFolder.root, "destination")
 
         whenever(mockContentResolver.openOutputStream(mockUri, "w"))

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -1,0 +1,36 @@
+package tech.ula.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ProotDebugLoggerTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    @Mock lateinit var mockDefaultSharedPreferences: SharedPreferences
+
+    private lateinit var prootDebugLogger: ProotDebugLogger
+
+    @Before
+    fun setup() {
+        prootDebugLogger = ProotDebugLogger(mockDefaultSharedPreferences, tempFolder.root.path)
+    }
+
+    @Test
+    fun `Property isEnabled fetches from cache`() {
+        whenever(mockDefaultSharedPreferences.getBoolean("pref_proot_debug_enabled", false))
+                .thenReturn(true)
+
+        assertTrue(prootDebugLogger.isEnabled)
+    }
+}

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -59,6 +59,7 @@ class ProotDebugLoggerTest {
         val outputFile = File(tempFolder.root, "test")
         val logFile = File(tempFolder.root, logName)
 
+        outputFile.createNewFile()
         outputFile.writeText(originalText)
         assertFalse(logFile.exists())
 
@@ -74,6 +75,7 @@ class ProotDebugLoggerTest {
         val outputFile = File(tempFolder.root, "test")
         val logFile = File(tempFolder.root, logName)
 
+        outputFile.createNewFile()
         outputFile.writeText(originalText)
         logFile.writeText("world hello")
 
@@ -87,6 +89,8 @@ class ProotDebugLoggerTest {
     fun `copyLogToDestination copies log to a URI-specified destination and returns true on success`() {
         val originalText = "copy world"
         val logFile = File(tempFolder.root, logName)
+
+        logFile.createNewFile()
         logFile.writeText(originalText)
 
         val destinationFile = File(tempFolder.root, "destination")

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -59,7 +59,6 @@ class ProotDebugLoggerTest {
         val outputFile = File(tempFolder.root, "test")
         val logFile = File(tempFolder.root, logName)
 
-        outputFile.createNewFile()
         outputFile.writeText(originalText)
         assertFalse(logFile.exists())
 
@@ -75,7 +74,6 @@ class ProotDebugLoggerTest {
         val outputFile = File(tempFolder.root, "test")
         val logFile = File(tempFolder.root, logName)
 
-        outputFile.createNewFile()
         outputFile.writeText(originalText)
         logFile.writeText("world hello")
 
@@ -90,7 +88,6 @@ class ProotDebugLoggerTest {
         val originalText = "copy world"
         val logFile = File(tempFolder.root, logName)
 
-        logFile.createNewFile()
         logFile.writeText(originalText)
 
         val destinationFile = File(tempFolder.root, "destination")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.31'
         android_plugin = '3.4.0'
-        jacoco_version = '0.8.4'
+        jacoco_version = '0.8.2'
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.31'
         android_plugin = '3.4.0'
-        jacoco_version = '0.8.2'
+        jacoco_version = '0.8.4'
     }
 
     dependencies {


### PR DESCRIPTION
**Describe the pull request**

This PR implements changes necessary for exporting the Proot debug log in Q. Instead of writing the log directly to public external storage, it is now written to scoped external storage. The user will then need to manually export it to public external storage if they want to share or view it. 

`DefaultPreferences` has been refactored into `ProotDebugLogger` which handles fetching values from the preference cache that are logically related, as well as writing, deleting, and exporting the log.

**Link to relevant issues**
N/A