### PR TITLE
Add logic to graphical app startup

### DIFF
--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -232,7 +232,7 @@ class AppsPreferences(private val prefs: SharedPreferences) {
         return when {
             pref.toLowerCase() == "ssh" || (app.supportsCli && !app.supportsGui) -> SshTypePreference
             pref.toLowerCase() == "xsdl" -> XsdlTypePreference
-            pref.toLowerCase() == "vnc" -> VncTypePreference
+            pref.toLowerCase() == "vnc" || (app.supportsGui && Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1) -> VncTypePreference
             else -> PreferenceHasNotBeenSelected
         }
     }


### PR DESCRIPTION
**Describe the pull request**

There was a visual bug that occurred when starting a GUI-only app on an Android 9.0 device.  It should start VNC automatically right after clicking the graphical-only app, instead it shows a dialog with SSH selected.  

This PR will fix the behavior to have VNC automatically selected.

**Link to relevant issues**
