### PR TITLE
Improve notifications

### DIFF
--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -78,6 +78,11 @@ class ServerService : Service() {
                 val filesystemId: Long = intent.getLongExtra("filesystemId", -1)
                 cleanUpFilesystem(filesystemId)
             }
+            "stopAll" -> {
+                activeSessions.forEach { (_, session) ->
+                    killSession(session)
+                }
+            }
         }
 
         return Service.START_STICKY

--- a/app/src/main/java/tech/ula/utils/NotificationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/NotificationUtility.kt
@@ -55,6 +55,7 @@ class NotificationUtility(val context: Context) {
                 .setContentText(serviceNotificationDescription)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
                 .setGroup(GROUP_KEY_USERLAND)
+                .setGroupSummary(true)
                 .setAutoCancel(false)
                 .setContentIntent(pendingSessionListIntent)
                 .addAction(R.drawable.ic_stat_icon, "Stop Sessions",

--- a/app/src/main/java/tech/ula/utils/NotificationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/NotificationUtility.kt
@@ -15,6 +15,7 @@ class NotificationUtility(val context: Context) {
 
     companion object {
         const val serviceNotificationId = 1000
+        const val GROUP_KEY_USERLAND = "tech.ula.userland"
     }
 
     private val serviceNotificationChannelId = context.getString(R.string.services_notification_channel_id)
@@ -48,6 +49,7 @@ class NotificationUtility(val context: Context) {
                 .setContentTitle(serviceNotificationTitle)
                 .setContentText(serviceNotificationDescription)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setGroup(GROUP_KEY_USERLAND)
                 .setAutoCancel(false)
                 .setContentIntent(pendingSessionListIntent)
 

--- a/app/src/main/java/tech/ula/utils/NotificationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/NotificationUtility.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import tech.ula.MainActivity
 import tech.ula.R
+import tech.ula.ServerService
 
 class NotificationUtility(val context: Context) {
 
@@ -44,6 +45,10 @@ class NotificationUtility(val context: Context) {
         val pendingSessionListIntent = PendingIntent
                 .getActivity(context, 0, sessionListIntent, 0)
 
+        val stopSessionsIntent = Intent(context, ServerService::class.java).putExtra("type", "stopAll")
+        val stopSessionsPendingIntent = PendingIntent.getService(context, 0,
+                stopSessionsIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+
         val builder = NotificationCompat.Builder(context, serviceNotificationChannelId)
                 .setSmallIcon(R.drawable.ic_stat_icon)
                 .setContentTitle(serviceNotificationTitle)
@@ -52,6 +57,8 @@ class NotificationUtility(val context: Context) {
                 .setGroup(GROUP_KEY_USERLAND)
                 .setAutoCancel(false)
                 .setContentIntent(pendingSessionListIntent)
+                .addAction(R.drawable.ic_stat_icon, "Stop Sessions",
+                        stopSessionsPendingIntent)
 
         return builder.build()
     }

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -43,7 +43,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
 
     private String TAG = "TermuxService";
 
-    private static final String NOTIFICATION_CHANNEL_ID = "termux_notification_channel";
+    private static final String NOTIFICATION_CHANNEL_ID = "UserLAndServices";
 
     /** Note that this is a symlink on the Android M preview. */
     @SuppressLint("SdCardPath")
@@ -52,7 +52,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
     public String prefixPath;
     public String homePath;
 
-    private static final int NOTIFICATION_ID = 1337;
+    private static final int NOTIFICATION_ID = 2000;
 
     private static final String ACTION_STOP_SERVICE = "com.termux.service_stop";
     private static final String ACTION_LOCK_WAKE = "com.termux.service_wake_lock";
@@ -172,6 +172,8 @@ public final class TermuxService extends Service implements SessionChangedCallba
         }
     }
 
+    String GROUP_KEY_USERLAND = "tech.ula.userland";
+
     private Notification buildNotification() {
         Intent notifyIntent = new Intent(this, TermuxActivity.class);
         // PendingIntent#getActivity(): "Note that the activity will be started outside of the context of an existing
@@ -195,6 +197,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
         builder.setSmallIcon(R.drawable.ic_service_notification);
         builder.setContentIntent(pendingIntent);
         builder.setOngoing(true);
+        builder.setGroup(GROUP_KEY_USERLAND);
 
         // If holding a wake or wifi lock consider the notification of high priority since it's using power,
         // otherwise use a low priority

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -158,7 +158,6 @@ public final class TermuxService extends Service implements SessionChangedCallba
         supportPath = filesPath + "/support/";
         prefixPath = filesPath + "/usr";
         homePath = filesPath + "/home";
-        setupNotificationChannel();
         startForeground(NOTIFICATION_ID, buildNotification());
     }
 
@@ -337,16 +336,4 @@ public final class TermuxService extends Service implements SessionChangedCallba
         });
     }
 
-    private void setupNotificationChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
-
-        String channelName = "UserLAnd Terminal";
-        String channelDescription = "Notifications from UserLAnd Terminal";
-        int importance = NotificationManager.IMPORTANCE_LOW;
-
-        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, channelName,importance);
-        channel.setDescription(channelDescription);
-        NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        manager.createNotificationChannel(channel);
-    }
 }


### PR DESCRIPTION
**Describe the pull request**

This PR introduces cleaning up the notifications for UserLAnd and adds additional functionality for the notification.  

There is one notification for the UserLAnd services and another for the terminal.  This PR will have it so only one is shown at a time.  If the terminal is being used, then the terminal notification will show itself in place of the services notification.  Once the terminal is exited, then the services notification will show back up.

Also a button is added to the services notification which adds the functionality to stop all running sessions in an easy to find location.

This is all shown in the gif below:


![Hello](https://media.giphy.com/media/W2L5XsSlKfDzAlyUXp/giphy.gif)

**Link to relevant issues**
