### PR TITLE
Migrate Terminal Code to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,7 +172,7 @@ dependencies {
 
     // Androidx versions
     def room_version = '2.1.0-beta01'
-    def navigation_version = '1.0.0'
+    def navigation_version = '2.1.0-alpha04'
     def lifecycle_version = '2.2.0-alpha01'
     def support_library_version = '1.1.0-alpha06'
     def preference_version = '1.1.0-alpha05'
@@ -188,8 +188,8 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation "android.arch.navigation:navigation-fragment-ktx:$navigation_version"
-    implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"
+    implementation "androidx.navigation:navigation-fragment-ktx:$navigation_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$navigation_version"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "androidx.preference:preference:$preference_version"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-android.enableJetifier=false
 android.useAndroidX=true

--- a/termux-app/terminal-term/build.gradle
+++ b/termux-app/terminal-term/build.gradle
@@ -8,8 +8,8 @@ android {
     }
 
     dependencies {
-        implementation "com.android.support:support-annotations:28.0.0"
         implementation "com.android.support:support-core-ui:28.0.0"
+        implementation "androidx.annotation:annotation:1.0.2"
         implementation project(":terminal-view")
     }
 

--- a/termux-app/terminal-term/build.gradle
+++ b/termux-app/terminal-term/build.gradle
@@ -8,8 +8,8 @@ android {
     }
 
     dependencies {
-        implementation "com.android.support:support-core-ui:28.0.0"
         implementation "androidx.annotation:annotation:1.0.2"
+        implementation "androidx.legacy:legacy-support-core-ui:1.0.0"
         implementation project(":terminal-view")
     }
 

--- a/termux-app/terminal-view/build.gradle
+++ b/termux-app/terminal-view/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     dependencies {
-        implementation "com.android.support:support-annotations:28.0.0"
+        implementation "androidx.annotation:annotation:1.0.2"
         api project(":terminal-emulator")
     }
 


### PR DESCRIPTION
**Describe the pull request**

This PR migrates the Terminal code to use AndroidX.

The following imports were updated:
 

- navigation-ui-ktx
- navigation-fragment-ktx
- support-annotations
- support-core-ui

**Link to relevant issues**
