### PR TITLE
Fix executables for older Android versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,4 @@ google-services.json
 app/src/main/resources/sentry.properties
 
 # Lib resources should be left out of source tree
-app/src/main/resources/lib/*
+app/src/main/jniLibs/*

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,14 +63,14 @@ android {
         }
     }
 
-    splits {
-        abi {
-            enable true
-            reset()
-            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
-            universalApk false
-        }
-    }
+//    splits {
+//        abi {
+//            enable true
+//            reset()
+//            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
+//            universalApk true
+//        }
+//    }
 
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,15 +63,6 @@ android {
         }
     }
 
-//    splits {
-//        abi {
-//            enable true
-//            reset()
-//            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
-//            universalApk true
-//        }
-//    }
-
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,15 @@ android {
         }
     }
 
+    splits {
+        abi {
+            enable true
+            reset()
+            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
+            universalApk false
+        }
+    }
+
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
@@ -165,7 +174,8 @@ task jacocoCoverageReportForCi(type: JacocoReport, dependsOn: ['testDebugUnitTes
 }
 
 ext.architectures = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
-ext.libDir = "$project.projectDir/src/main/resources/lib"
+//ext.libDir = "$project.projectDir/src/main/resources/lib"
+ext.libDir = "$project.projectDir/src/main/jniLibs"
 
 task downloadAssets(type: Download) {
     def assetVersion = "v1.0.0"
@@ -189,6 +199,8 @@ task fetchAssets(dependsOn: downloadAssets) {
                 rename '(.*)\\+\\+_(.*)', '$1pp$2'
                 rename '(.*)-(.*)', '$1$2'
                 rename '(.*).so', '$1'
+                // Lib files must start with 'lib' and end with '.so.'
+                rename '(.*)', 'lib_$1.so'
             }
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -196,9 +196,6 @@ task fetchAssets(dependsOn: downloadAssets) {
             copy {
                 from "$buildDir/$arch"
                 into "$libDir/$arch"
-                rename '(.*)\\+\\+_(.*)', '$1pp$2'
-                rename '(.*)-(.*)', '$1$2'
-                rename '(.*).so', '$1'
                 // Lib files must start with 'lib' and end with '.so.'
                 rename '(.*)', 'lib_$1.so'
             }

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -153,7 +153,12 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         } catch (err: NoSuchFileException) {
             logger.sendEvent(err.file.name)
             displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_file_missing)
-        } catch (err: Exception) {
+        } catch (err: NullPointerException) {
+            logger.sendEvent("NPE when looking for lib directory")
+            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_no_lib_directory)
+        }
+        catch (err: Exception) {
+            logger.sendEvent("$err")
             displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_setup_failure)
         }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -148,7 +148,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         notificationManager.createServiceNotificationChannel() // Android O requirement
         try {
             CoroutineScope(Dispatchers.Main).launch {
-                ulaFiles.setupSupportDir()
                 ulaFiles.setupLinks()
             }
         } catch (err: NoSuchFileException) {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -156,8 +156,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         } catch (err: NullPointerException) {
             logger.sendEvent("NPE when looking for lib directory")
             displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_no_lib_directory)
-        }
-        catch (err: Exception) {
+        } catch (err: Exception) {
             logger.sendEvent("$err")
             displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_setup_failure)
         }

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -1,6 +1,7 @@
 package tech.ula.utils
 
 import android.os.Environment
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -128,7 +129,7 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
 
     fun getBusyboxEnv(): HashMap<String, String> {
         return hashMapOf(
-                "LIB_PATH" to ulaFiles.libDir.absolutePath,
+                "LIB_PATH" to ulaFiles.supportDir.absolutePath,
                 "ROOT_PATH" to ulaFiles.filesDir.absolutePath
         )
     }
@@ -144,8 +145,8 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
 
     fun getProotEnv(filesystemDir: File, prootDebugLevel: String): HashMap<String, String> {
         return hashMapOf(
-                "LD_LIBRARY_PATH" to ulaFiles.libLinkDir.absolutePath,
-                "LIB_PATH" to ulaFiles.libDir.absolutePath,
+                "LD_LIBRARY_PATH" to ulaFiles.supportDir.absolutePath,
+                "LIB_PATH" to ulaFiles.supportDir.absolutePath,
                 "ROOT_PATH" to ulaFiles.filesDir.absolutePath,
                 "ROOTFS_PATH" to filesystemDir.absolutePath,
                 "PROOT_DEBUG_LEVEL" to prootDebugLevel,

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -1,7 +1,6 @@
 package tech.ula.utils
 
 import android.os.Environment
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -27,7 +27,6 @@ class UlaFiles(
         libDir.listFiles().forEach { libFile ->
             val name = libFile.name.toSupportName()
             val linkFile = File(supportDir, name)
-            if (!libFile.exists()) throw NoSuchFileException(libFile)
             linkFile.delete()
             symlinker.createSymlink(libFile.path, linkFile.path)
         }

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -17,55 +17,16 @@ class UlaFiles(
     val proot = File(supportDir, "proot")
 
     // Lib files must start with 'lib' and end with '.so.'
-    private fun String.toLibName(): String {
-        return "lib_$this.so"
-    }
-
-    internal val supportDirFileRequirements = listOf(
-            "busybox",
-            "dbclient",
-            "proot",
-            "addNonRootUser.sh",
-            "busybox_static",
-            "compressFilesystem.sh",
-            "extractFilesystem.sh",
-            "execInProot.sh",
-            "isServerInProcTree.sh",
-            "killProcTree.sh",
-            "stat4",
-            "stat8",
-            "uptime"
-    )
-
-    internal val libDirectorySymlinkMapping = listOf(
-            "libc++_shared.so" to "libcppshared",
-            "libcrypto.so.1.1" to "libcrypto.1.1",
-            "libleveldb.so.1" to "libleveldb.1",
-            "libtalloc.so.2" to "libtalloc.2",
-            "libtermux-auth.so" to "libtermuxauth",
-            "libutil.so" to "libutil"
-    )
-
-    suspend fun setupSupportDir() = withContext(Dispatchers.IO) {
-        supportDir.mkdirs()
-
-        supportDirFileRequirements.forEach { filename ->
-            val assetFile = File(libDir, filename.toLibName())
-            val target = File(supportDir, filename)
-            if (!assetFile.exists()) throw NoSuchFileException(assetFile)
-            target.delete()
-            symlinker.createSymlink(assetFile.path, target.path)
-//            assetFile.copyTo(target, overwrite = true)
-//            makePermissionsUsable(supportDir.path, filename)
-        }
+    private fun String.toSupportName(): String {
+        return this.substringAfter("lib_").substringBeforeLast(".so")
     }
 
     suspend fun setupLinks() = withContext(Dispatchers.IO) {
         supportDir.mkdirs()
 
-        libDirectorySymlinkMapping.forEach { (requiredLinkName, actualLibName) ->
-            val linkFile = File(supportDir, requiredLinkName)
-            val libFile = File(libDir, actualLibName.toLibName())
+        libDir.listFiles().forEach { libFile ->
+            val name = libFile.name.toSupportName()
+            val linkFile = File(supportDir, name)
             if (!libFile.exists()) throw NoSuchFileException(libFile)
             linkFile.delete()
             symlinker.createSymlink(libFile.path, linkFile.path)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_export_copy_public_external_failure">Copying backup to external public storage failed.</string>
     <string name="error_library_file_missing">It looks like we\'re missing a required library!</string>
     <string name="error_library_setup_failure">It looks like initial setup failed. Please contact us on Github.</string>
+    <string name="error_no_lib_directory">It looks like the library directory we are looking for does not exist. Please contact us on Github.</string>
 
     <!-- Download Failure Reasons -->
     <string name="download_failure_http_error">Http Error: %1$s</string>

--- a/termux-app/terminal-term/src/main/java/com/termux/app/BackgroundJob.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/BackgroundJob.java
@@ -112,7 +112,7 @@ public final class BackgroundJob {
             final String pathEnv = "PATH=" + System.getenv("PATH");
             return new String[]{termEnv, homeEnv, prefixEnv, androidRootEnv, androidDataEnv, pathEnv, externalStorageEnv};
         } else {
-            final String ldEnv = "LD_LIBRARY_PATH=" + files_path + "/lib";
+            final String ldEnv = "LD_LIBRARY_PATH=" + files_path + "/support";
             final String langEnv = "LANG=en_US.UTF-8";
             final String pathEnv = "PATH=" + prefix_path + "/bin:" + prefix_path + "/bin/applets";
             final String pwdEnv = "PWD=" + cwd;

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -259,10 +259,8 @@ public final class TermuxService extends Service implements SessionChangedCallba
         String[] env = BackgroundJob.buildEnvironment(failSafe, cwd, filesPath, homePath, prefixPath);
         boolean isLoginShell = false;
 
-        String libPath = this.getApplicationInfo().nativeLibraryDir + "/";
-
         for (String shellBinary : new String[]{"busybox"}) {
-            File shellFile = new File(libPath + shellBinary);
+            File shellFile = new File(supportPath + shellBinary);
             if (shellFile.canExecute()) {
                 executablePath = shellFile.getAbsolutePath();
                 break;
@@ -270,7 +268,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
         }
 
         // TODO: Replace -y -y option with a way to support hostkey checking
-        String[] dbclientArgs = {"sh", "-c", libPath + "dbclient -y -y " + username + "@" + hostname + "/" + port};
+        String[] dbclientArgs = {"sh", "-c", supportPath + "dbclient -y -y " + username + "@" + hostname + "/" + port};
         String[] processArgs = BackgroundJob.setupProcessArgs(executablePath, dbclientArgs, prefixPath);
         executablePath = processArgs[0];
         int lastSlashIndex = executablePath.lastIndexOf('/');


### PR DESCRIPTION
**Describe the pull request**
Older versions of Android don't play nicely with things being placed in `src/main/resources/lib/<abi>`. Instead, libraries and executables need to be placed in `src/main/jniLibs/<abi>`. This PR moves those files to the appropriate place and updates the implementation to just symlink all of them to `files/support`, more closely mirroring the old implementation.

Files placed in `jniLibs` must begin with `lib` and end with `.so` to be extracted by older versions of Android.

**Link to relevant issues**
N/A