### PR TITLE
Hotfix for deleting filesystem crash.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 65
-        versionName "2.5.11"
+        versionCode 66
+        versionName "2.5.12"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -23,10 +23,10 @@ class BusyboxExecutor(
     private val discardOutput: (String) -> Any = { }
 
     fun executeScript(
-        command: String,
+        scriptCall: String,
         listener: (String) -> Any = discardOutput
     ): ExecutionResult {
-        val updatedCommand = busyboxWrapper.wrapScript(command)
+        val updatedCommand = busyboxWrapper.wrapScript(scriptCall)
 
         return runCommand(updatedCommand, listener)
     }

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -1,7 +1,6 @@
 package tech.ula.utils
 
 import android.os.Environment
-import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -31,8 +30,9 @@ class BusyboxExecutor(
         return runCommand(updatedCommand, listener)
     }
 
-    fun executeCommand(command: String,
-                       listener: (String) -> Any = discardOutput
+    fun executeCommand(
+        command: String,
+        listener: (String) -> Any = discardOutput
     ): ExecutionResult {
         val updatedCommand = busyboxWrapper.wrapCommand(command)
 
@@ -116,10 +116,7 @@ class BusyboxExecutor(
 
     suspend fun recursivelyDelete(absolutePath: String): ExecutionResult = withContext(Dispatchers.IO) {
         val command = "rm -rf $absolutePath"
-        val listener: (String) -> Unit = { line ->
-            Log.e("delete", line)
-        }
-        return@withContext executeCommand(command, listener = listener)
+        return@withContext executeCommand(command)
     }
 
     private fun collectOutput(inputStream: InputStream, listener: (String) -> Any) {

--- a/app/src/main/java/tech/ula/utils/ServerUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ServerUtility.kt
@@ -118,7 +118,7 @@ class ServerUtility(
 
     fun stopService(session: Session) {
         val command = "support/killProcTree.sh ${session.pid} ${session.pid()}"
-        val result = busyboxExecutor.executeCommand(command)
+        val result = busyboxExecutor.executeScript(command)
         if (result is FailedExecution) {
             logger.logRuntimeErrorForCommand(functionName = "stopService", command = command, err = result.reason)
         }
@@ -129,7 +129,7 @@ class ServerUtility(
         // The server itself is run by a third-party, so we can consider this to always be true.
         // The third-party app is responsible for handling errors starting their server.
         if (session.serviceType == "xsdl") return true
-        val result = busyboxExecutor.executeCommand(command)
+        val result = busyboxExecutor.executeScript(command)
         return when (result) {
             is SuccessfulExecution -> true
             is FailedExecution -> {

--- a/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
+++ b/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
@@ -103,7 +103,7 @@ class BusyboxExecutorTest {
         stubBusyboxCommand(testCommand)
         stubBusyboxEnv()
 
-        val result = busyboxExecutor.executeCommand(testCommand, testListener)
+        val result = busyboxExecutor.executeScript(testCommand, testListener)
 
         assertEquals(1, outputCollection.size)
         assertEquals(testOutput, outputCollection[0])
@@ -116,7 +116,7 @@ class BusyboxExecutorTest {
         val testCommand = "echo $testOutput"
         stubBusyboxIsPresent(false)
 
-        val result = busyboxExecutor.executeCommand(testCommand, testListener)
+        val result = busyboxExecutor.executeScript(testCommand, testListener)
         assertTrue(result is MissingExecutionAsset)
         result as MissingExecutionAsset
         assertEquals("busybox", result.asset)
@@ -129,7 +129,7 @@ class BusyboxExecutorTest {
         stubBusyboxCommand(testCommand)
         stubBusyboxEnv()
 
-        val result = busyboxExecutor.executeCommand(testCommand, testListener)
+        val result = busyboxExecutor.executeScript(testCommand, testListener)
         assertTrue(result is FailedExecution)
     }
 

--- a/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
+++ b/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
@@ -138,13 +138,17 @@ class BusyboxExecutorTest {
     }
 
     @Test
-    fun `Successfully executes scripts, using BusyboxWrapper#wrapScript`() {
-        val testScript = "example/script.sh"
+    fun `Successfully executes 'scripts', using BusyboxWrapper#wrapScript`() {
+        val testOutput = "hello"
+        val testCommand = "echo $testOutput"
         stubBusyboxIsPresent(true)
-        stubBusyboxScript(testScript)
+        stubBusyboxScript(testCommand)
         stubBusyboxEnv()
 
-        val result = busyboxExecutor.executeCommand(testScript, testListener)
+        val result = busyboxExecutor.executeScript(testCommand, testListener)
+
+        assertEquals(1, outputCollection.size)
+        assertEquals(testOutput, outputCollection[0])
         assertTrue(result is SuccessfulExecution)
     }
 

--- a/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
+++ b/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
@@ -66,7 +66,11 @@ class BusyboxExecutorTest {
     }
 
     private fun stubBusyboxCommand(command: String) {
-        whenever(mockBusyboxWrapper.addBusybox(command)).thenReturn(command.toExecutableList())
+        whenever(mockBusyboxWrapper.wrapCommand(command)).thenReturn(command.toExecutableList())
+    }
+
+    private fun stubBusyboxScript(command: String) {
+        whenever(mockBusyboxWrapper.wrapScript(command)).thenReturn(command.toExecutableList())
     }
 
     private fun stubBusyboxEnv() {
@@ -103,7 +107,7 @@ class BusyboxExecutorTest {
         stubBusyboxCommand(testCommand)
         stubBusyboxEnv()
 
-        val result = busyboxExecutor.executeScript(testCommand, testListener)
+        val result = busyboxExecutor.executeCommand(testCommand, testListener)
 
         assertEquals(1, outputCollection.size)
         assertEquals(testOutput, outputCollection[0])
@@ -122,15 +126,26 @@ class BusyboxExecutorTest {
         assertEquals("busybox", result.asset)
     }
 
-    @Test()
+    @Test
     fun `Fails to execute illegal commands, 'adding' busybox`() {
         val testCommand = "badCommand"
         stubBusyboxIsPresent(true)
         stubBusyboxCommand(testCommand)
         stubBusyboxEnv()
 
-        val result = busyboxExecutor.executeScript(testCommand, testListener)
+        val result = busyboxExecutor.executeCommand(testCommand, testListener)
         assertTrue(result is FailedExecution)
+    }
+
+    @Test
+    fun `Successfully executes scripts, using BusyboxWrapper#wrapScript`() {
+        val testScript = "example/script.sh"
+        stubBusyboxIsPresent(true)
+        stubBusyboxScript(testScript)
+        stubBusyboxEnv()
+
+        val result = busyboxExecutor.executeCommand(testScript, testListener)
+        assertTrue(result is SuccessfulExecution)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
@@ -221,7 +221,7 @@ class ServerUtilityTest {
         val session = Session(0, filesystemId = filesystemId, serviceType = "ssh")
         serverUtility.stopService(session)
         val command = "support/killProcTree.sh ${session.pid} -1"
-        verify(mockBusyboxExecutor).executeCommand(eq(command), anyOrNull())
+        verify(mockBusyboxExecutor).executeScript(eq(command), anyOrNull())
     }
 
     @Test
@@ -230,7 +230,7 @@ class ServerUtilityTest {
         val command = "support/killProcTree.sh ${session.pid} -1"
 
         val reason = "reason"
-        whenever(mockBusyboxExecutor.executeCommand(eq(command), anyOrNull()))
+        whenever(mockBusyboxExecutor.executeScript(eq(command), anyOrNull()))
                 .thenReturn(FailedExecution("reason"))
 
         serverUtility.stopService(session)
@@ -245,7 +245,7 @@ class ServerUtilityTest {
         val result = serverUtility.isServerRunning(session)
 
         assertTrue(result)
-        verify(mockBusyboxExecutor, never()).executeCommand(anyOrNull(), anyOrNull())
+        verify(mockBusyboxExecutor, never()).executeScript(anyOrNull(), anyOrNull())
         verify(mockLogUtility, never()).logRuntimeErrorForCommand(anyOrNull(), anyOrNull(), anyOrNull())
     }
 
@@ -253,7 +253,7 @@ class ServerUtilityTest {
     fun `Calls appropriate command to check if server is running, and returns the result`() {
         val session = Session(0, filesystemId = filesystemId, serviceType = "ssh")
         val command = "support/isServerInProcTree.sh -1"
-        whenever(mockBusyboxExecutor.executeCommand(eq(command), anyOrNull()))
+        whenever(mockBusyboxExecutor.executeScript(eq(command), anyOrNull()))
                 .thenReturn(SuccessfulExecution)
                 .thenReturn(FailedExecution(""))
 
@@ -269,7 +269,7 @@ class ServerUtilityTest {
         val session = Session(0, filesystemId = filesystemId, serviceType = "ssh")
         val command = "support/isServerInProcTree.sh -1"
         val reason = "reason"
-        whenever(mockBusyboxExecutor.executeCommand(eq(command), anyOrNull()))
+        whenever(mockBusyboxExecutor.executeScript(eq(command), anyOrNull()))
                 .thenReturn(FailedExecution(reason))
 
         val result = serverUtility.isServerRunning(session)


### PR DESCRIPTION
**Describe the pull request**
A bug was introduced in which we were wrapping basic busybox commands incorrectly. Commands still need the `-c` option sent to `busybox sh` whereas scripts can no longer use it due to the changes made to allow multi-user environments. This PR codifies this discrepancy by introducing a separate function `BusyboxExecutor#executeScript` and calls the appropriate functions in the right places.

**Link to relevant issues**
N/A