### PR TITLE
Fix crash on EditText.

### DIFF
--- a/app/src/main/res/layout/dia_app_credentials.xml
+++ b/app/src/main/res/layout/dia_app_credentials.xml
@@ -28,6 +28,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:inputType="textNoSuggestions|textVisiblePassword"
+            android:hint="@string/hint_username"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/text_filesystem_credentials_reasoning">
@@ -37,8 +38,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
-                android:inputType="text"
-                android:hint="@string/hint_username" />
+                android:inputType="text" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -50,6 +50,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
+            android:hint="@string/hint_password"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_username">
@@ -59,7 +60,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
-                android:hint="@string/hint_password"
                 android:inputType="textPassword" />
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -71,6 +71,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
+            android:hint="@string/hint_vnc_password"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/text_input_layout_password">
@@ -80,7 +81,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
-                android:hint="@string/hint_vnc_password"
                 android:inputType="textPassword" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
**Describe the pull request**

Apparently hints must be an attribute of the containing `InputTextLayout` on older versions of Android due to a bug in the platform.

**Link to relevant issues**
N/A