### PR TITLE
Hotfix notification crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "tech.ula"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 66
-        versionName "2.5.12"
+        versionCode 67
+        versionName "2.5.13"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/tech/ula/utils/NotificationUtility.kt
+++ b/app/src/main/java/tech/ula/utils/NotificationUtility.kt
@@ -17,9 +17,8 @@ class NotificationUtility(val context: Context) {
     companion object {
         const val serviceNotificationId = 1000
         const val GROUP_KEY_USERLAND = "tech.ula.userland"
+        const val serviceNotificationChannelId = "UserLAnd"
     }
-
-    private val serviceNotificationChannelId = context.getString(R.string.services_notification_channel_id)
 
     private val serviceNotificationTitle = context.getString(R.string.service_notification_title)
     private val serviceNotificationDescription = context.getString(R.string.service_notification_description)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -85,7 +85,6 @@
     <string name="prompt_install_file_manager">الرجاء تثبيت مدير الملفات</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAnd خدمات</string>
     <string name="services_notification_channel_name">خدمات</string>
     <string name="services_notification_channel_description">الخدمات المستمرة</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,7 +86,6 @@
     <string name="prompt_app_connection_type_preference">Seleccione el tipo de conexión: </string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">ServiciosDeUserLAnd</string>
     <string name="services_notification_channel_name">Servicios</string>
     <string name="services_notification_channel_description">Servicios persistentes</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -51,7 +51,6 @@
     <string name="prompt_app_connection_type_preference">لطفا نوع اتصال را تعیین کنید: </string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">خدمات یوزرلند</string>
     <string name="services_notification_channel_name">خدمات</string>
     <string name="services_notification_channel_description">خدمات مداوم</string>
     <string name="service_notification_title">یوزرلند</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,6 @@
     <string name="prompt_app_connection_type_preference">Veuillez choisir un type de connexion :</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">Services</string>
     <string name="services_notification_channel_description">Services persistants</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-jp/strings.xml
+++ b/app/src/main/res/values-jp/strings.xml
@@ -51,7 +51,6 @@
     <string name="prompt_app_connection_type_preference">接続方法を選択してください:</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndサービス</string>
     <string name="services_notification_channel_name">サービス</string>
     <string name="services_notification_channel_description">続行中のサービス</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -98,7 +98,6 @@
     <string name="prompt_install_file_manager">Por favor, instale um gerenciador de arquivos</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">Serviços</string>
     <string name="services_notification_channel_description">Serviços persistentes</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -78,7 +78,6 @@
     <string name="prompt_app_connection_type_preference">Тип соединения:</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">Службы</string>
     <string name="services_notification_channel_description">Постоянные службы</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -38,7 +38,6 @@
     <string name="prompt_filesystem">文件系统：</string>
     <string name="prompt_service_type">服务类别：</string>
     <string name="prompt_client_type">客户端类别：</string>
-    <string name="services_notification_channel_id">UserLAnd服务</string>
     <string name="services_notification_channel_name">服务</string>
     <string name="services_notification_channel_description">永久服务</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -96,7 +96,6 @@
     <string name="prompt_install_file_manager">請安裝檔案管理員</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">服務</string>
     <string name="services_notification_channel_description">永久服務</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,6 @@
     <string name="prompt_install_file_manager">Please install a File Manager</string>
 
     <!-- Notification strings -->
-    <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">Services</string>
     <string name="services_notification_channel_description">Persistent services</string>
     <string name="service_notification_title">UserLAnd</string>

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxService.java
@@ -44,7 +44,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
 
     private String TAG = "TermuxService";
 
-    private static final String NOTIFICATION_CHANNEL_ID = "UserLAndServices";
+    private static final String NOTIFICATION_CHANNEL_ID = "UserLAnd";
 
     /** Note that this is a symlink on the Android M preview. */
     @SuppressLint("SdCardPath")


### PR DESCRIPTION
**Describe the pull request**

This PR fixes the issues for devices that crash upon opening a userland terminal.  This behavior was noticed on devices with languages other than English.  

The problem came from a mismatch of notification channel IDs, the Userland "app" notification was changing its notification channel ID when the language was set to something else besides english.  This causes a crash because the terminal couldn't find the channel it was looking for.  

The solution is just to set the channel ID as a hardcoded string that matches on the "app" side and the terminal side.

**Link to relevant issues**
