### PR TITLE
Add UserLAnd DocumentProvider.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,18 @@
             android:name=".ServerService"
             android:stopWithTask="true" />
 
+        <provider
+            android:name="tech.ula.provider.UlaDocProvider"
+            android:authorities="tech.ula.documents"
+            android:grantUriPermissions="true"
+            android:exported="true"
+            android:permission="android.permission.MANAGE_DOCUMENTS">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
+
+
     </application>
 
 </manifest>

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -69,9 +69,9 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
-    private val ulaFiles by lazy { UlaFiles(this.filesDir, this.storageRoot, File(this.applicationInfo.nativeLibraryDir)) }
+    private val ulaFiles by lazy { UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir)) }
     private val busyboxExecutor by lazy {
-        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.scopedStorageRoot.path)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }
 
@@ -130,7 +130,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
         val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val downloadManagerWrapper = DownloadManagerWrapper(downloadManager)
-        val downloadUtility = DownloadUtility(assetPreferences, downloadManagerWrapper, filesDir, this.storageRoot)
+        val downloadUtility = DownloadUtility(assetPreferences, downloadManagerWrapper, filesDir, this.scopedStorageRoot)
 
         val appsPreferences = AppsPreferences(this.getSharedPreferences("apps", Context.MODE_PRIVATE))
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private val logger = SentryLogger()
     private val ulaFiles by lazy { UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir)) }
     private val busyboxExecutor by lazy {
-        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.scopedStorageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -32,7 +32,7 @@ class ServerService : Service() {
 
     private val busyboxExecutor by lazy {
         val ulaFiles = UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir))
-        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.scopedStorageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -31,8 +31,8 @@ class ServerService : Service() {
     }
 
     private val busyboxExecutor by lazy {
-        val ulaFiles = UlaFiles(this.filesDir, this.storageRoot, File(this.applicationInfo.nativeLibraryDir))
-        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.storageRoot.path)
+        val ulaFiles = UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir))
+        val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, this.scopedStorageRoot.path)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }
 

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -42,7 +42,7 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun addUlaRoots(result: MatrixCursor): Cursor {
-        val baseDir = context!!.scopedStorageRoot
+        val baseDir = File(context!!.scopedStorageRoot, "home")
         result.newRow().apply {
             add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
             // Root for Ula storage should be the files dir

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -1,0 +1,150 @@
+package tech.ula.provider
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsProvider
+import android.webkit.MimeTypeMap
+import tech.ula.R
+import java.io.File
+
+class UlaDocProvider : DocumentsProvider() {
+
+    private val defaultRootProjection: Array<String> = arrayOf(
+            Root.COLUMN_ROOT_ID,
+            Root.COLUMN_FLAGS,
+            Root.COLUMN_ICON,
+            Root.COLUMN_TITLE,
+            Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_AVAILABLE_BYTES
+    )
+
+    private val defaultDocumentProjection: Array<String> = arrayOf(
+            Document.COLUMN_DOCUMENT_ID,
+            Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_DISPLAY_NAME,
+            Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
+            Document.COLUMN_SIZE
+    )
+
+    override fun onCreate(): Boolean { return true }
+
+    override fun queryRoots(projection: Array<out String>?): Cursor {
+        val result = MatrixCursor(projection ?: defaultRootProjection)
+        return context?.let {
+            addUlaRoots(result)
+        } ?: result
+    }
+
+    private fun addUlaRoots(result: MatrixCursor): Cursor {
+        val baseDir = context!!.filesDir
+        result.newRow().apply {
+            add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
+            // Root for Ula storage should be the files dir
+            add(Root.COLUMN_ROOT_ID, getDocIdForFile(baseDir))
+            add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(baseDir))
+
+            // Allow creation and searching
+            add(Root.COLUMN_FLAGS,
+                    Root.FLAG_SUPPORTS_CREATE /*or*/
+//                    Root.FLAG_SUPPORTS_SEARCH
+            )
+            add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+            add(Root.COLUMN_AVAILABLE_BYTES, baseDir.freeSpace)
+        }
+        return result
+    }
+
+    override fun openDocument(docId: String, mode: String, signal: CancellationSignal): ParcelFileDescriptor {
+        val file = getFileForDocId(docId)
+        val accessMode = ParcelFileDescriptor.parseMode(mode)
+        return ParcelFileDescriptor.open(file, accessMode)
+    }
+
+    override fun queryDocument(docId: String?, projection: Array<out String>?): Cursor {
+        return MatrixCursor(projection ?: defaultDocumentProjection).apply {
+            includeDocId(this, docId = docId ?: "")
+        }
+    }
+
+    override fun queryChildDocuments(
+            parentDocumentId: String?,
+            projection: Array<out String>?,
+            sortOrder: String?
+    ): Cursor {
+        val parent: File = getFileForDocId(parentDocumentId ?: "")
+        return MatrixCursor(projection ?: defaultDocumentProjection).apply {
+            parent.listFiles()
+                    .forEach { file ->
+                        includeFile(this, file = file)
+                    }
+        }
+
+    }
+
+    override fun getDocumentType(documentId: String?): String {
+        return getMimeType(getFileForDocId(docId = documentId ?: ""))
+    }
+
+    private fun getDocIdForFile(file: File): String {
+        return file.absolutePath
+    }
+
+    private fun getFileForDocId(docId: String): File {
+        return File(docId)
+    }
+
+    private fun includeDocId(result: MatrixCursor, docId: String) {
+        if (docId == "") return
+
+        val file = getFileForDocId(docId)
+        addToCursor(result, docId, file)
+    }
+
+    private fun includeFile(
+            result: MatrixCursor,
+            file: File
+    ) {
+        if (!file.exists()) return
+
+        val docId = getDocIdForFile(file)
+        addToCursor(result, docId, file)
+    }
+
+    private fun addToCursor(result: MatrixCursor, docId: String, file: File) {
+        val editFlags = when {
+            file.isDirectory && file.canWrite() -> Document.FLAG_DIR_SUPPORTS_CREATE
+            file.canWrite() -> Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_DELETE
+            else -> 0
+        }
+
+        val mimeType = getMimeType(file)
+        val allFlags = if (mimeType.startsWith("image/")) {
+            editFlags or Document.FLAG_SUPPORTS_THUMBNAIL
+        } else editFlags
+
+        result.newRow().apply {
+            add(Document.COLUMN_DOCUMENT_ID, docId)
+            add(Document.COLUMN_DISPLAY_NAME, file.name)
+            add(Document.COLUMN_SIZE, file.length())
+            add(Document.COLUMN_MIME_TYPE, mimeType)
+            add(Document.COLUMN_LAST_MODIFIED, file.lastModified())
+            add(Document.COLUMN_FLAGS, allFlags)
+            add(Document.COLUMN_ICON, R.mipmap.ic_launcher)
+        }
+    }
+
+    private fun getMimeType(file: File): String {
+        if (file.isDirectory) return Document.MIME_TYPE_DIR
+        val extension = file.name.substringAfterLast('.')
+        if (extension != "") {
+            val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            if (mimeType != null) return mimeType
+        }
+        return "application/octet-stream"
+    }
+}

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -1,9 +1,7 @@
 package tech.ula.provider
 
-import android.content.res.AssetFileDescriptor
 import android.database.Cursor
 import android.database.MatrixCursor
-import android.graphics.Point
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract.Root
@@ -58,9 +56,9 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     override fun queryChildDocuments(
-            parentDocumentId: String?,
-            projection: Array<out String>?,
-            sortOrder: String?
+        parentDocumentId: String?,
+        projection: Array<out String>?,
+        sortOrder: String?
     ): Cursor {
         val parent: File = getFileForDocId(parentDocumentId ?: "")
         return MatrixCursor(projection ?: defaultDocumentProjection).apply {
@@ -69,7 +67,6 @@ class UlaDocProvider : DocumentsProvider() {
                         includeFile(this, file = file)
                     }
         }
-
     }
 
     override fun getDocumentType(documentId: String?): String {
@@ -123,8 +120,8 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun includeFile(
-            result: MatrixCursor,
-            file: File
+        result: MatrixCursor,
+        file: File
     ) {
         if (!file.exists()) return
 

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -9,6 +9,7 @@ import android.provider.DocumentsContract.Document
 import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
 import tech.ula.R
+import tech.ula.utils.scopedStorageRoot
 import java.io.File
 
 class UlaDocProvider : DocumentsProvider() {
@@ -41,7 +42,7 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun addUlaRoots(result: MatrixCursor): Cursor {
-        val baseDir = context!!.filesDir
+        val baseDir = context!!.scopedStorageRoot
         result.newRow().apply {
             add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
             // Root for Ula storage should be the files dir

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -88,6 +88,12 @@ class UlaDocProvider : DocumentsProvider() {
         return getDocIdForFile(file)
     }
 
+    override fun deleteDocument(documentId: String?) {
+        if (documentId == null) return
+        val file = getFileForDocId(documentId)
+        file.delete()
+    }
+
     private fun addUlaRoots(result: MatrixCursor): Cursor {
         val baseDir = File(context!!.scopedStorageRoot, "home")
         result.newRow().apply {

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -45,8 +45,8 @@ class FilesystemListFragment : Fragment() {
         val filesystemDao = UlaDatabase.getInstance(activityContext).filesystemDao()
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
 
-        val ulaFiles = UlaFiles(activityContext.filesDir, activityContext.storageRoot, File(activityContext.applicationInfo.nativeLibraryDir))
-        val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, activityContext.storageRoot.path)
+        val ulaFiles = UlaFiles(activityContext.filesDir, activityContext.scopedStorageRoot, File(activityContext.applicationInfo.nativeLibraryDir))
+        val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, activityContext.scopedStorageRoot.path)
         val busyboxExecutor = BusyboxExecutor(ulaFiles, prootDebugLogger)
 
         val filesystemUtility = FilesystemUtility(activityContext.filesDir.absolutePath, busyboxExecutor)

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -46,7 +46,7 @@ class FilesystemListFragment : Fragment() {
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
 
         val ulaFiles = UlaFiles(activityContext.filesDir, activityContext.scopedStorageRoot, File(activityContext.applicationInfo.nativeLibraryDir))
-        val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, activityContext.scopedStorageRoot.path)
+        val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, ulaFiles)
         val busyboxExecutor = BusyboxExecutor(ulaFiles, prootDebugLogger)
 
         val filesystemUtility = FilesystemUtility(activityContext.filesDir.absolutePath, busyboxExecutor)

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -14,16 +14,20 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import tech.ula.utils.ProotDebugLogger
+import tech.ula.utils.UlaFiles
 import tech.ula.utils.defaultSharedPreferences
 import tech.ula.utils.scopedStorageRoot
+import java.io.File
 import kotlin.coroutines.CoroutineContext
 
 private const val EXPORT_REQUEST_CODE = 42
 
 class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
 
+
     private val prootDebugLogger by lazy {
-        ProotDebugLogger(activity!!.defaultSharedPreferences, activity!!.scopedStorageRoot.path)
+        val ulaFiles = UlaFiles(activity!!.filesDir, activity!!.scopedStorageRoot, File(activity!!.applicationInfo.nativeLibraryDir))
+        ProotDebugLogger(activity!!.defaultSharedPreferences, ulaFiles)
     }
 
     private val job = Job()

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -24,7 +24,6 @@ private const val EXPORT_REQUEST_CODE = 42
 
 class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
 
-
     private val prootDebugLogger by lazy {
         val ulaFiles = UlaFiles(activity!!.filesDir, activity!!.scopedStorageRoot, File(activity!!.applicationInfo.nativeLibraryDir))
         ProotDebugLogger(activity!!.defaultSharedPreferences, ulaFiles)

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import tech.ula.utils.ProotDebugLogger
 import tech.ula.utils.defaultSharedPreferences
-import tech.ula.utils.storageRoot
+import tech.ula.utils.scopedStorageRoot
 import kotlin.coroutines.CoroutineContext
 
 private const val EXPORT_REQUEST_CODE = 42
@@ -23,7 +23,7 @@ private const val EXPORT_REQUEST_CODE = 42
 class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
 
     private val prootDebugLogger by lazy {
-        ProotDebugLogger(activity!!.defaultSharedPreferences, activity!!.storageRoot.path)
+        ProotDebugLogger(activity!!.defaultSharedPreferences, activity!!.scopedStorageRoot.path)
     }
 
     private val job = Job()

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -1,6 +1,5 @@
 package tech.ula.utils
 
-import android.os.Environment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -167,9 +167,7 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
                 "ROOT_PATH" to ulaFiles.filesDir.absolutePath,
                 "ROOTFS_PATH" to filesystemDir.absolutePath,
                 "PROOT_DEBUG_LEVEL" to prootDebugLevel,
-                // TODO this should change as part of Q, but we need a way to import public files
-//                "EXTRA_BINDINGS" to "-b ${ulaFiles.scopedDir.absolutePath}:/sdcard",
-                "EXTRA_BINDINGS" to "-b ${Environment.getExternalStorageDirectory()}:/sdcard",
+                "EXTRA_BINDINGS" to "-b ${ulaFiles.scopedUserDir.absolutePath}:/sdcard",
                 "OS_VERSION" to System.getProperty("os.version")
         )
     }

--- a/app/src/main/java/tech/ula/utils/Extensions.kt
+++ b/app/src/main/java/tech/ula/utils/Extensions.kt
@@ -33,11 +33,11 @@ fun <A, B> zipLiveData(a: LiveData<A>, b: LiveData<B>): LiveData<Pair<A, B>> {
     }
 }
 
-inline val Context.storageRoot: File
+inline val Context.scopedStorageRoot: File
     get() = this.getExternalFilesDir(null) ?: run {
-        val storageRoot = File(this.filesDir, "storage")
-        storageRoot.mkdirs()
-        storageRoot
+        val scopedStorageRoot = File(this.filesDir, "storage")
+        scopedStorageRoot.mkdirs()
+        scopedStorageRoot
     }
 
 inline val Context.defaultSharedPreferences: SharedPreferences

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 
-class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootPath: String) {
+class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, scopedStorageRootPath: String) {
     private val prefs = defaultSharedPreferences
 
     val isEnabled: Boolean
@@ -20,7 +20,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, storageRootP
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
     val logName = "Proot_Debug_Log.txt"
-    private val logLocation = "$storageRootPath/$logName"
+    private val logLocation = "$scopedStorageRootPath/$logName"
 
     fun logStream(
         inputStream: InputStream,

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -20,7 +20,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, scopedStorag
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
     val logName = "Proot_Debug_Log.txt"
-    private val logLocation = "$scopedStorageRootPath/$logName"
+    private val logLocation = "$scopedStorageRootPath/home/$logName"
 
     fun logStream(
         inputStream: InputStream,

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 
-class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, scopedStorageRootPath: String) {
+class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, ulaFiles: UlaFiles) {
     private val prefs = defaultSharedPreferences
 
     val isEnabled: Boolean
@@ -20,7 +20,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, scopedStorag
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
     val logName = "Proot_Debug_Log.txt"
-    private val logLocation = "$scopedStorageRootPath/home/$logName"
+    private val logLocation = "${ulaFiles.scopedUserDir}/$logName"
 
     fun logStream(
         inputStream: InputStream,

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -12,6 +12,11 @@ class UlaFiles(
 ) {
 
     val supportDir: File = File(filesDir, "support")
+    val scopedUserDir: File = File(scopedDir, "home")
+
+    init {
+        scopedUserDir.mkdirs()
+    }
 
     val busybox = File(supportDir, "busybox")
     val proot = File(supportDir, "proot")

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -23,6 +23,8 @@ class ProotDebugLoggerTest {
 
     @Mock lateinit var mockDefaultSharedPreferences: SharedPreferences
 
+    @Mock lateinit var mockUlaFiles: UlaFiles
+
     @Mock lateinit var mockContentResolver: ContentResolver
 
     @Mock lateinit var mockUri: Uri
@@ -33,7 +35,9 @@ class ProotDebugLoggerTest {
 
     @Before
     fun setup() {
-        prootDebugLogger = ProotDebugLogger(mockDefaultSharedPreferences, tempFolder.root.path)
+        whenever(mockUlaFiles.scopedUserDir).thenReturn(tempFolder.root)
+
+        prootDebugLogger = ProotDebugLogger(mockDefaultSharedPreferences, mockUlaFiles)
     }
 
     @Test


### PR DESCRIPTION
## What changes does this PR introduce?
This PR introduces the `UlaDocProvider`, an implementation of a framework component that allows easy import/export from the system file manager. This document provider exposes `<scopedStorage>/home` as a user facing directory on an external partition that can be accessed both through the file manager, and through a new binding (to `/sdcard`).

## Any background context you want to provide?
With the changes to scoped storage coming in Q, we can no longer set a PRoot binding directly to public external storage like we were before. 

## Where should the reviewer start?
Everything interesting is in `UlaDocProvider`.

## Has this been manually tested? How?
Yes, by copying files into and out of it using the file manager and the binding.

## What value does this provide to our end users?
An easy way to import and export files from filesystems post-Q.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/QCAaqb7STvc3u/giphy.gif)
