### PR TITLE
Add clarifier to beta version names. Fix automated changelogs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,11 @@ reference:
       name: Decode Play store key
       command: echo $PLAY_KEY | base64 -di > ${HOME}/play-key.json
 
+  place_version_code: &place_version_code
+    run:
+      name: Move version code to expected location
+      command: cp ~/workspace/app/versionCode.txt app/versionCode.txt
+
   configure_sentry_beta: &configure_sentry_beta
     run:
       name: Configure Sentry for production use
@@ -270,6 +275,7 @@ jobs:
       - *attach_release_workspace
       - *export_play_key
       - *decode_play_key
+      - *place_version_code
       - run:
           name: Deploy to Play store beta
           command: bundle exec fastlane deploy_beta
@@ -284,6 +290,7 @@ jobs:
       - *attach_release_workspace
       - *export_play_key
       - *decode_play_key
+      - *place_version_code
       - *export_github_release_token
       - run:
           name: Deploy to Play store production and Github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: ./gradlew ktlint
       - run:
           name: Build
-          command: ./gradlew -PciBuild=true :app:assembleRelease
+          command: ./gradlew -PciBuild=true :app:assembleBeta
       - *persist_release_workspace
       - store_artifacts:
           path: app/build/outputs/apk/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ reference:
       paths:
         - app/build
         - app/versionCode.txt
+        - app/versionName.txt
   attach_firebase_workspace: &attach_firebase_workspace
     attach_workspace:
       at: *workspace
@@ -102,10 +103,12 @@ reference:
       name: Decode Play store key
       command: echo $PLAY_KEY | base64 -di > ${HOME}/play-key.json
 
-  place_version_code: &place_version_code
+  place_version_information: &place_version_information
     run:
-      name: Move version code to expected location
-      command: cp ~/workspace/app/versionCode.txt app/versionCode.txt
+      name: Move version code and name files to expected location for fastlane
+      command: |
+        cp ~/workspace/app/versionCode.txt app/versionCode.txt
+        cp ~/workspace/app/versionName.txt app/versionName.txt
 
   configure_sentry_beta: &configure_sentry_beta
     run:
@@ -275,7 +278,7 @@ jobs:
       - *attach_release_workspace
       - *export_play_key
       - *decode_play_key
-      - *place_version_code
+      - *place_version_information
       - run:
           name: Deploy to Play store beta
           command: bundle exec fastlane deploy_beta
@@ -290,7 +293,7 @@ jobs:
       - *attach_release_workspace
       - *export_play_key
       - *decode_play_key
-      - *place_version_code
+      - *place_version_information
       - *export_github_release_token
       - run:
           name: Deploy to Play store production and Github

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ android {
             testCoverageEnabled true
         }
         beta {
-            versionNameSuffix "-beta"
+            versionNameSuffix "-beta-$versionCode"
             debuggable false
             minifyEnabled false
             signingConfig signingConfigs.beta
@@ -116,6 +116,8 @@ tasks.withType(Test) {
 task reportVersionCode {
     new File("$projectDir/versionCode.txt").text = "$project.android.defaultConfig.versionCode"
 }
+// By running this task before builds, we guarantee that the same version is used for the fastlane
+// to supply the automated changelogs.
 preBuild.dependsOn reportVersionCode
 
 task reportVersionName {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,13 @@ android {
             minifyEnabled false
             testCoverageEnabled true
         }
+        beta {
+            versionNameSuffix "-beta"
+            debuggable false
+            minifyEnabled false
+            signingConfig signingConfigs.release
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             debuggable false
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,7 @@ tasks.withType(Test) {
 task reportVersionCode {
     new File("$projectDir/versionCode.txt").text = "$project.android.defaultConfig.versionCode"
 }
+preBuild.dependsOn reportVersionCode
 
 task reportVersionName {
     new File("$projectDir/versionName.txt").text = "$project.android.defaultConfig.versionName"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,12 @@ android {
     }
 
     signingConfigs {
+        beta {
+            storeFile project.file('../keystore.jks')
+            keyAlias System.getenv('ANDROID_KEY_ALIAS')
+            storePassword System.getenv('ANDROID_STORE_PASSWORD')
+            keyPassword System.getenv('ANDROID_KEY_PASSWORD')
+        }
         release {
             storeFile project.file('../keystore.jks')
             keyAlias System.getenv('ANDROID_KEY_ALIAS')
@@ -63,7 +69,7 @@ android {
             versionNameSuffix "-beta"
             debuggable false
             minifyEnabled false
-            signingConfig signingConfigs.release
+            signingConfig signingConfigs.beta
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ android {
             testCoverageEnabled true
         }
         beta {
-            versionNameSuffix "-beta-$versionCode"
+            versionNameSuffix "-beta-$defaultConfig.versionCode"
             debuggable false
             minifyEnabled false
             signingConfig signingConfigs.beta

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,7 @@ preBuild.dependsOn reportVersionCode
 task reportVersionName {
     new File("$projectDir/versionName.txt").text = "$project.android.defaultConfig.versionName"
 }
+preBuild.dependsOn reportVersionName
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,7 +57,7 @@ platform :android do
   desc "Deploy a new version to Google Play beta track"
   lane :deploy_beta do
     update_changelogs
-    supply(apk: "app/build/outputs/apk/release/app-release.apk", track: "beta")
+    supply(apk: "app/build/outputs/apk/beta/app-beta.apk", track: "beta")
   end
 
   desc "Deploy a new version to the Google Play production track and Github releases"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,6 @@ platform :android do
 
   desc "Update changelogs based on latest version code"
   lane :update_changelogs do
-    gradle(task: "reportVersionCode")
     version_code = File.read("../app/versionCode.txt")
 
     changelog = changelog_from_git_commits(merge_commit_filtering: "exclude_merges", pretty: "- %s")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,12 +33,10 @@ platform :android do
 
   desc "Release to Github"
   lane :github_release do
-    gradle(task: "reportVersionCode")
     version_code = File.read("../app/versionCode.txt")
     changelogs_dir = "metadata/android/en-US/changelogs"
     changelog_file = changelogs_dir + "/" + version_code + ".txt"
 
-    gradle(task: "reportVersionName")
     version_name = File.read("../app/versionName.txt")
     release_name = "v" + version_name
 

--- a/termux-app/terminal-emulator/build.gradle
+++ b/termux-app/terminal-emulator/build.gradle
@@ -19,6 +19,10 @@ android {
     }
 
     buildTypes {
+        beta {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/termux-app/terminal-term/build.gradle
+++ b/termux-app/terminal-term/build.gradle
@@ -14,6 +14,10 @@ android {
     }
 
     buildTypes {
+        beta {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/termux-app/terminal-view/build.gradle
+++ b/termux-app/terminal-view/build.gradle
@@ -15,6 +15,10 @@ android {
     }
 
     buildTypes {
+        beta {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
**Note**
I'll manually stop the CD workflow since I intend to make a release with user-facing changes today or tomorrow.

## What changes does this PR introduce?
This PR allows beta versions to be assembled such that their version name is <versionName>-beta-<versionCode>. This should allow us to more easily determine what build users are on when they report issues.

## Any background context you want to provide?
Need an easier way to have users report their version than relying on version code.

## Where should the reviewer start?
`app/build.gradle`

## Has this been manually tested? How?
Kind of. I've made sure that 
- The name reflects the version code in the built APK.
- update_changelogs lane works correctly if files are in the right place.
- Version information files are generated during build tasks.

The one sticking point will be whether the version information files are correctly persisted across
CI jobs. I _think_ I did it right but I'm wrong about that 90% of the time conservatively.

## What value does this provide to our end users?
Better issue reporting and tracking of which beta build they are on.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/nJPkKr231dvKo/giphy.gif)
