### PR TITLE
Display progress while deleting filesystems and fail appropriately.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -57,7 +57,7 @@ import tech.ula.ui.FilesystemListFragment
 import tech.ula.model.repositories.DownloadMetadata
 import java.io.File
 
-class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection, FilesystemListFragment.ExportFilesystem {
+class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppListFragment.AppSelection, FilesystemListFragment.FilesystemListProgress {
 
     val className = "MainActivity"
 
@@ -555,12 +555,17 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         }
     }
 
-    override fun updateExportProgress(details: String) {
+    override fun updateFilesystemExportProgress(details: String) {
         val step = getString(R.string.progress_exporting_filesystem)
         updateProgressBar(step, details)
     }
 
-    override fun stopExportProgress() {
+    override fun updateFilesystemDeleteProgress() {
+        val step = getString(R.string.progress_deleting_filesystem)
+        updateProgressBar(step, "")
+    }
+
+    override fun stopProgressFromFilesystemList() {
         killProgressBar()
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -36,10 +36,6 @@ class ServerService : Service() {
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }
 
-    private val filesystemUtility by lazy {
-        FilesystemUtility(this.filesDir.path, busyboxExecutor)
-    }
-
     private val serverUtility by lazy {
         ServerUtility(this.filesDir.path, busyboxExecutor)
     }
@@ -200,17 +196,8 @@ class ServerService : Service() {
     }
 
     private fun cleanUpFilesystem(filesystemId: Long) {
-        // TODO This could potentially be handled by the main activity (viewmodel) now
-        if (filesystemId == (-1).toLong()) {
-            val exception = IllegalStateException("Did not receive filesystemId")
-            SentryLogger().addExceptionBreadcrumb(exception)
-            throw exception
-        }
-
         activeSessions.values.filter { it.filesystemId == filesystemId }
                 .forEach { killSession(it) }
-
-        CoroutineScope(Dispatchers.Main).launch { filesystemUtility.deleteFilesystem(filesystemId) }
     }
 
     private fun sendSessionActivatedBroadcast() {

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -136,13 +136,12 @@ class FilesystemListFragment : Fragment() {
     }
 
     private fun deleteFilesystem(filesystem: Filesystem): Boolean {
-        filesystemListViewModel.deleteFilesystemById(filesystem.id)
-
         val serviceIntent = Intent(activityContext, ServerService::class.java)
         serviceIntent.putExtra("type", "filesystemIsBeingDeleted")
         serviceIntent.putExtra("filesystemId", filesystem.id)
         activityContext.startService(serviceIntent)
 
+        filesystemListViewModel.deleteFilesystemById(filesystem.id)
         return true
     }
 

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -192,6 +192,7 @@ class FilesystemListFragment : Fragment() {
                 activityContext.stopProgressFromFilesystemList()
             }
             is FilesystemDeleteState.Failure -> {
+                displayGenericErrorDialog(activityContext, R.string.general_error_title, R.string.error_filesystem_delete)
                 activityContext.stopProgressFromFilesystemList()
             }
         }

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -79,9 +79,6 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
     fun deleteFilesystemById(id: Long, coroutineScope: CoroutineScope = this) = coroutineScope.launch {
         withContext(Dispatchers.IO) {
             viewState.postValue(FilesystemDeleteState.InProgress)
-//            activeSessions.value?.let { list ->
-//                list.filter { it.filesystemId == id }.forEach { killSession(it) }
-//            }
 
             try {
                 filesystemUtility.deleteFilesystem(id)

--- a/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/FilesystemListViewModel.kt
@@ -18,6 +18,8 @@ import kotlin.coroutines.CoroutineContext
 import tech.ula.model.entities.Session
 import tech.ula.utils.ExecutionResult
 import tech.ula.utils.FailedExecution
+import tech.ula.utils.SentryLogger
+import java.io.IOException
 
 sealed class FilesystemListViewState
 
@@ -82,7 +84,8 @@ class FilesystemListViewModel(private val filesystemDao: FilesystemDao, private 
 
             try {
                 filesystemUtility.deleteFilesystem(id)
-            } catch (err: Exception) {
+            } catch (err: IOException) {
+                SentryLogger().sendEvent("FilesystemList delete failure")
                 viewState.postValue(FilesystemDeleteState.Failure)
                 return@withContext
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="progress_starting">Starting service&#8230;</string>
     <string name="progress_clearing_support_files">Clearing all support files&#8230;</string>
     <string name="progress_exporting_filesystem">Exporting filesystem</string>
+    <string name="progress_deleting_filesystem">Deleting filesystem</string>
 
     <!-- Preferences -->
     <string name="pref_app_category">App Preferences</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="error_library_file_missing">It looks like we\'re missing a required library!</string>
     <string name="error_library_setup_failure">It looks like initial setup failed. Please contact us on Github.</string>
     <string name="error_no_lib_directory">It looks like the library directory we are looking for does not exist. Please contact us on Github.</string>
+    <string name="error_filesystem_delete">Deleting filesystem failed! Try stopping all sessions and trying again.</string>
 
     <!-- Download Failure Reasons -->
     <string name="download_failure_http_error">Http Error: %1$s</string>


### PR DESCRIPTION
## What changes does this PR introduce?
This PR moves management of deleting filesystems to the filesystem list VM, and displays a progress dialog for it.

## Any background context you want to provide?
Previously, deletion of the filesystem entity in the database was handled by the VM but actual deletion of the directory structure was handled by `ServerService`. This caused "hanging" filesystems where the deletion of the db entry would succeed regardless of whether the deletion of the directory structure succeeded.

## Where should the reviewer start?
`FilesystemListFragment` or `FilesystemListViewModel`.

## Has this been manually tested? How?
By deleting a filesystem.

## What value does this provide to our end users?
More clarity about background processes and smaller application size.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/1Y7ChRtbWnYONjDidg/giphy.gif)
