### PR TITLE
Sync executables on session startup.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -135,7 +135,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         val appsPreferences = AppsPreferences(this.getSharedPreferences("apps", Context.MODE_PRIVATE))
 
         val appsStartupFsm = AppsStartupFsm(ulaDatabase, appsPreferences, filesystemUtility)
-        val sessionStartupFsm = SessionStartupFsm(ulaDatabase, assetRepository, filesystemUtility, downloadUtility, storageUtility)
+        val sessionStartupFsm = SessionStartupFsm(ulaDatabase, ulaFiles, assetRepository, filesystemUtility, downloadUtility, storageUtility)
         ViewModelProviders.of(this, MainActivityViewModelFactory(appsStartupFsm, sessionStartupFsm))
                 .get(MainActivityViewModel::class.java)
     }
@@ -146,20 +146,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
         notificationManager.createServiceNotificationChannel() // Android O requirement
-//        try {
-//            CoroutineScope(Dispatchers.Main).launch {
-//                ulaFiles.setupLinks()
-//            }
-//        } catch (err: NoSuchFileException) {
-//            logger.sendEvent(err.file.name)
-//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_file_missing)
-//        } catch (err: NullPointerException) {
-//            logger.sendEvent("NPE when looking for lib directory")
-//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_no_lib_directory)
-//        } catch (err: Exception) {
-//            logger.sendEvent("$err")
-//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_setup_failure)
-//        }
 
         setNavStartDestination()
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -501,6 +501,10 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 val step = getString(R.string.progress_start_step)
                 updateProgressBar(step, "")
             }
+            is SettingUpLinks -> {
+                val step = getString(R.string.progress_link_step)
+                updateProgressBar(step, "")
+            }
             is FetchingAssetLists -> {
                 val step = getString(R.string.progress_fetching_asset_lists)
                 updateProgressBar(step, "")

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -146,20 +146,20 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
         notificationManager.createServiceNotificationChannel() // Android O requirement
-        try {
-            CoroutineScope(Dispatchers.Main).launch {
-                ulaFiles.setupLinks()
-            }
-        } catch (err: NoSuchFileException) {
-            logger.sendEvent(err.file.name)
-            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_file_missing)
-        } catch (err: NullPointerException) {
-            logger.sendEvent("NPE when looking for lib directory")
-            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_no_lib_directory)
-        } catch (err: Exception) {
-            logger.sendEvent("$err")
-            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_setup_failure)
-        }
+//        try {
+//            CoroutineScope(Dispatchers.Main).launch {
+//                ulaFiles.setupLinks()
+//            }
+//        } catch (err: NoSuchFileException) {
+//            logger.sendEvent(err.file.name)
+//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_file_missing)
+//        } catch (err: NullPointerException) {
+//            logger.sendEvent("NPE when looking for lib directory")
+//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_no_lib_directory)
+//        } catch (err: Exception) {
+//            logger.sendEvent("$err")
+//            displayGenericErrorDialog(this, R.string.general_error_title, R.string.error_library_setup_failure)
+//        }
 
         setNavStartDestination()
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -468,7 +468,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private fun handleClearSupportFiles() {
         val appsPreferences = AppsPreferences(this.getSharedPreferences("apps", Context.MODE_PRIVATE))
         val assetDirectoryNames = appsPreferences.getDistributionsList().plus("support")
-        val assetFileClearer = AssetFileClearer(this.filesDir, assetDirectoryNames, busyboxExecutor)
+        val assetFileClearer = AssetFileClearer(ulaFiles, assetDirectoryNames, busyboxExecutor)
         CoroutineScope(Dispatchers.Main).launch { viewModel.handleClearSupportFiles(assetFileClearer) }
     }
 

--- a/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/SessionStartupFsm.kt
@@ -17,6 +17,7 @@ import java.net.UnknownHostException
 
 class SessionStartupFsm(
     ulaDatabase: UlaDatabase,
+    private val ulaFiles: UlaFiles,
     private val assetRepository: AssetRepository,
     private val filesystemUtility: FilesystemUtility,
     private val downloadUtility: DownloadUtility,
@@ -72,7 +73,8 @@ class SessionStartupFsm(
         val currentState = state.value!!
         return when (event) {
             is SessionSelected -> currentState is WaitingForSessionSelection
-            is RetrieveAssetLists -> currentState is SessionIsReadyForPreparation
+            is SetupLinks -> currentState is SessionIsReadyForPreparation
+            is RetrieveAssetLists -> currentState is LinkSetupState.Success
             is GenerateDownloads -> currentState is AssetListsRetrievalSucceeded
             is DownloadAssets -> currentState is DownloadsRequired
             is AssetDownloadComplete -> {
@@ -102,6 +104,7 @@ class SessionStartupFsm(
         }
         when (event) {
             is SessionSelected -> { handleSessionSelected(event.session) }
+            is SetupLinks -> { handleLinkSetup() }
             is RetrieveAssetLists -> { handleRetrieveAssetLists(event.filesystem) }
             is GenerateDownloads -> { handleGenerateDownloads(event.filesystem, event.assetList) }
             is DownloadAssets -> { handleDownloadAssets(event.downloadRequirements) }
@@ -133,6 +136,20 @@ class SessionStartupFsm(
 
         val filesystem = findFilesystemForSession(session)
         state.postValue(SessionIsReadyForPreparation(session, filesystem))
+    }
+
+    private suspend fun handleLinkSetup() {
+        state.postValue(LinkSetupState.InProgress)
+        try {
+            ulaFiles.setupLinks()
+        } catch (err: NoSuchFileException) {
+            state.postValue(LinkSetupState.Failure.LibFileNotFound)
+        } catch (err: NullPointerException) {
+            state.postValue(LinkSetupState.Failure.LibDirNotFound)
+        } catch (err: Exception) {
+            state.postValue(LinkSetupState.Failure.General("$err"))
+        }
+        state.postValue(LinkSetupState.Success)
     }
 
     private suspend fun handleRetrieveAssetLists(filesystem: Filesystem) {
@@ -301,6 +318,16 @@ object SingleSessionSupported : SessionStartupState()
 data class SessionIsRestartable(val session: Session) : SessionStartupState()
 data class SessionIsReadyForPreparation(val session: Session, val filesystem: Filesystem) : SessionStartupState()
 
+sealed class LinkSetupState : SessionStartupState() {
+    object InProgress : LinkSetupState()
+    object Success : LinkSetupState()
+    sealed class Failure : LinkSetupState() {
+        object LibDirNotFound : Failure()
+        object LibFileNotFound : Failure()
+        data class General(val message: String) : Failure()
+    }
+}
+
 // Asset retrieval states
 sealed class AssetRetrievalState : SessionStartupState()
 object RetrievingAssetLists : AssetRetrievalState()
@@ -346,6 +373,7 @@ object StorageVerificationCompletedSuccessfully : StorageVerificationState()
 
 sealed class SessionStartupEvent
 data class SessionSelected(val session: Session) : SessionStartupEvent()
+object SetupLinks : SessionStartupEvent()
 data class RetrieveAssetLists(val filesystem: Filesystem) : SessionStartupEvent()
 data class GenerateDownloads(val filesystem: Filesystem, val assetList: List<Asset>) : SessionStartupEvent()
 data class DownloadAssets(val downloadRequirements: List<DownloadMetadata>) : SessionStartupEvent()

--- a/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
+++ b/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
@@ -6,15 +6,20 @@ import java.io.IOException
 import java.lang.Exception
 
 class AssetFileClearer(
-    private val filesDir: File,
+    private val ulaFiles: UlaFiles,
     private val assetDirectoryNames: Set<String>,
     private val busyboxExecutor: BusyboxExecutor,
     private val logger: Logger = SentryLogger()
 ) {
     @Throws(Exception::class)
     suspend fun clearAllSupportAssets() {
-        if (!filesDir.exists()) {
+        if (!ulaFiles.filesDir.exists()) {
             val exception = FileNotFoundException()
+            logger.addExceptionBreadcrumb(exception)
+            throw exception
+        }
+        if (!ulaFiles.busybox.exists()) {
+            val exception = IllegalStateException("Busybox missing")
             logger.addExceptionBreadcrumb(exception)
             throw exception
         }
@@ -24,7 +29,7 @@ class AssetFileClearer(
 
     @Throws(IOException::class)
     private suspend fun clearTopLevelAssets(assetDirectoryNames: Set<String>) {
-        for (file in filesDir.listFiles()) {
+        for (file in ulaFiles.filesDir.listFiles()) {
             if (!file.isDirectory) continue
             if (!assetDirectoryNames.contains(file.name)) continue
             if (file.name == "support") continue
@@ -38,7 +43,7 @@ class AssetFileClearer(
 
     @Throws(IOException::class)
     private suspend fun clearFilesystemSupportAssets() {
-        for (file in filesDir.listFiles()) {
+        for (file in ulaFiles.filesDir.listFiles()) {
             if (!file.isDirectory || file.name.toIntOrNull() == null) continue
 
             val supportDirectory = File("${file.absolutePath}/support")

--- a/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
+++ b/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
@@ -24,21 +24,11 @@ class AssetFileClearer(
 
     @Throws(IOException::class)
     private suspend fun clearTopLevelAssets(assetDirectoryNames: Set<String>) {
-        val supportDirName = "support"
         for (file in filesDir.listFiles()) {
             if (!file.isDirectory) continue
             if (!assetDirectoryNames.contains(file.name)) continue
-            // Removing the support directory must happen last since it contains busybox
-            if (file.name == supportDirName) continue
+            if (file.name == "support") continue
             if (busyboxExecutor.recursivelyDelete(file.absolutePath) !is SuccessfulExecution) {
-                val exception = IOException()
-                logger.addExceptionBreadcrumb(exception)
-                throw exception
-            }
-        }
-        val supportDir = File("${filesDir.absolutePath}/$supportDirName")
-        if (supportDir.exists()) {
-            if (busyboxExecutor.recursivelyDelete(supportDir.absolutePath) !is SuccessfulExecution) {
                 val exception = IOException()
                 logger.addExceptionBreadcrumb(exception)
                 throw exception

--- a/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
+++ b/app/src/main/java/tech/ula/utils/AssetFileClearer.kt
@@ -3,7 +3,6 @@ package tech.ula.utils
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
-import java.lang.Exception
 
 class AssetFileClearer(
     private val ulaFiles: UlaFiles,
@@ -11,7 +10,7 @@ class AssetFileClearer(
     private val busyboxExecutor: BusyboxExecutor,
     private val logger: Logger = SentryLogger()
 ) {
-    @Throws(Exception::class)
+    @Throws(FileNotFoundException::class, IllegalStateException::class)
     suspend fun clearAllSupportAssets() {
         if (!ulaFiles.filesDir.exists()) {
             val exception = FileNotFoundException()

--- a/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
+++ b/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
@@ -67,6 +67,9 @@ class IllegalStateHandler {
             is InsufficientAvailableStorage -> {
                 LocalizationData(R.string.illegal_state_insufficient_storage)
             }
+            is BusyboxMissing -> {
+                LocalizationData(R.string.illegal_state_busybox_missing)
+            }
         }
     }
 }

--- a/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
+++ b/app/src/main/java/tech/ula/utils/IllegalStateHandler.kt
@@ -34,6 +34,15 @@ class IllegalStateHandler {
             is NoSessionSelectedWhenTransitionNecessary -> {
                 LocalizationData(R.string.illegal_state_no_session_selected_when_preparation_started)
             }
+            is LibFileNotFound -> {
+                LocalizationData(R.string.error_library_file_missing)
+            }
+            is LibDirNotFound -> {
+                LocalizationData(R.string.error_no_lib_directory)
+            }
+            is ErrorSettingUpLinks -> {
+                LocalizationData(R.string.error_library_setup_failure)
+            }
             is ErrorFetchingAssetLists -> {
                 LocalizationData(R.string.illegal_state_error_fetching_asset_lists)
             }

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -27,7 +27,7 @@ class UlaFiles(
         return this.substringAfter("lib_").substringBeforeLast(".so")
     }
 
-    @Throws(Exception::class)
+    @Throws(NullPointerException::class, NoSuchFileException::class, Exception::class)
     suspend fun setupLinks() = withContext(Dispatchers.IO) {
         supportDir.mkdirs()
 

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -3,6 +3,7 @@ package tech.ula.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.lang.NullPointerException
 
 class UlaFiles(
     val filesDir: File,
@@ -26,6 +27,7 @@ class UlaFiles(
         return this.substringAfter("lib_").substringBeforeLast(".so")
     }
 
+    @Throws(Exception::class)
     suspend fun setupLinks() = withContext(Dispatchers.IO) {
         supportDir.mkdirs()
 

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -15,7 +15,6 @@ import tech.ula.model.repositories.DownloadMetadata
 import tech.ula.model.state.* // ktlint-disable no-wildcard-imports
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import java.io.FileNotFoundException
-import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
 class MainActivityViewModel(
@@ -292,9 +291,9 @@ class MainActivityViewModel(
             is LinkSetupState.Success -> { doTransitionIfRequirementsAreSelected {
                 submitSessionStartupEvent(RetrieveAssetLists(lastSelectedFilesystem))
             } }
-            is LinkSetupState.Failure.LibDirNotFound -> { state.postValue(LibDirNotFound) }
-            is LinkSetupState.Failure.LibFileNotFound -> { state.postValue(LibFileNotFound) }
-            is LinkSetupState.Failure.General -> { state.postValue(ErrorSettingUpLinks) }
+            is LinkSetupState.Failure.LibDirNotFound -> { postIllegalStateWithLog(LibDirNotFound) }
+            is LinkSetupState.Failure.LibFileNotFound -> { postIllegalStateWithLog(LibFileNotFound) }
+            is LinkSetupState.Failure.General -> { postIllegalStateWithLog(ErrorSettingUpLinks) }
         }
     }
 

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -14,6 +14,7 @@ import tech.ula.model.entities.Session
 import tech.ula.model.repositories.DownloadMetadata
 import tech.ula.model.state.* // ktlint-disable no-wildcard-imports
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
+import java.io.FileNotFoundException
 import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
@@ -173,8 +174,10 @@ class MainActivityViewModel(
         try {
             assetFileClearer.clearAllSupportAssets()
             state.postValue(ProgressBarOperationComplete)
-        } catch (err: Exception) {
+        } catch (err: FileNotFoundException) {
             postIllegalStateWithLog(FailedToClearSupportFiles)
+        } catch (err: IllegalStateException) {
+            postIllegalStateWithLog(BusyboxMissing)
         }
     }
 
@@ -440,6 +443,7 @@ object FailedToCopyAssetsToFilesystem : IllegalState()
 data class FailedToExtractFilesystem(val reason: String) : IllegalState()
 object FailedToClearSupportFiles : IllegalState()
 object InsufficientAvailableStorage : IllegalState()
+object BusyboxMissing : IllegalState()
 
 sealed class UserInputRequiredState : State()
 object FilesystemCredentialsRequired : UserInputRequiredState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,9 +110,8 @@
     <string name="illegal_state_failed_to_extract_filesystem">Failed to extract filesystem. Try clearing support files. Failure reason: %1$s</string>
     <string name="illegal_state_failed_to_clear_support_files">Failed to clear support files.</string>
     <string name="illegal_state_insufficient_storage">Failed to detect sufficient storage.  Try increasing the available storage on your device to at least 250 MB.</string>
-
-    <!-- Misc illegal state -->
     <string name="illegal_state_unhandled_session_service_type">Trying to start a session with an unknown service type.</string>
+    <string name="illegal_state_busybox_missing">Busybox is required for this operation. Try running a session to make sure it is installed.</string>
 
     <!-- Prompts -->
     <string name="prompt_filesystem">Filesystem:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
 
     <!-- Progress bar messages -->
     <string name="progress_start_step">Getting things ready for you&#8230;</string>
+    <string name="progress_link_step">Settings up links&#8230;</string>
     <string name="progress_fetching_asset_lists">Fetching asset lists&#8230;</string>
     <string name="progress_checking_for_required_updates">Checking whether updates are required&#8230;</string>
     <string name="progress_downloading">Downloading required assets&#8230;</string>

--- a/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
@@ -95,7 +95,7 @@ class AssetFileClearerTest {
         verify(busyboxExecutor, never()).recursivelyDelete(randomTopLevelDir.absolutePath)
 
         verify(busyboxExecutor).recursivelyDelete(debianDir.absolutePath)
-        verify(busyboxExecutor).recursivelyDelete(supportDir.absolutePath)
+        verify(busyboxExecutor, never()).recursivelyDelete(supportDir.absolutePath)
         verify(busyboxExecutor, never()).recursivelyDelete(topLevelDebianAssetFile.absolutePath)
         verify(busyboxExecutor, never()).recursivelyDelete(topLevelSupportAssetFile.absolutePath)
 

--- a/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetFileClearerTest.kt
@@ -21,41 +21,43 @@ class AssetFileClearerTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
+    @Mock lateinit var mockUlaFiles: UlaFiles
+
     @Mock lateinit var busyboxExecutor: BusyboxExecutor
 
     @Mock lateinit var mockLogger: Logger
 
-    lateinit var filesDir: File
-    lateinit var supportDir: File
-    lateinit var debianDir: File
-    lateinit var filesystemDir: File
+    private lateinit var filesDir: File
+    private lateinit var supportDir: File
+    private lateinit var debianDir: File
+    private lateinit var filesystemDir: File
 
-    lateinit var filesystemSupportDir: File
-    lateinit var topLevelSupportAssetFile: File
-    lateinit var topLevelDebianAssetFile: File
-    lateinit var hiddenFilesystemSupportFile: File
-    lateinit var nestedFilesystemAssetFile: File
-    lateinit var randomTopLevelFile: File
-    lateinit var randomTopLevelDir: File
+    private lateinit var filesystemSupportDir: File
+    private lateinit var topLevelSupportAssetFile: File
+    private lateinit var topLevelDebianAssetFile: File
+    private lateinit var hiddenFilesystemSupportFile: File
+    private lateinit var nestedFilesystemAssetFile: File
+    private lateinit var randomTopLevelFile: File
+    private lateinit var randomTopLevelDir: File
 
-    val filesDirName = "filesDir"
-    val debianDirName = "debian"
-    val supportDirName = "support"
-    val filesystemDirName = "1"
-    val assetDirectoryNames = setOf(debianDirName, supportDirName)
-    val assetName = "asset"
-    val hiddenFileName = ".hidden_file"
+    private val filesDirName = "filesDir"
+    private val debianDirName = "debian"
+    private val supportDirName = "support"
+    private val filesystemDirName = "1"
+    private val assetDirectoryNames = setOf(debianDirName, supportDirName)
+    private val assetName = "asset"
+    private val hiddenFileName = ".hidden_file"
 
-    lateinit var assetFileClearer: AssetFileClearer
+    private lateinit var assetFileClearer: AssetFileClearer
 
     @Before
     fun setup() {
         createTestFiles()
 
-        assetFileClearer = AssetFileClearer(filesDir, assetDirectoryNames, busyboxExecutor, mockLogger)
+        assetFileClearer = AssetFileClearer(mockUlaFiles, assetDirectoryNames, busyboxExecutor, mockLogger)
     }
 
-    fun createTestFiles() {
+    private fun createTestFiles() {
         randomTopLevelFile = tempFolder.newFile()
         randomTopLevelDir = tempFolder.newFolder()
         filesDir = tempFolder.newFolder(filesDirName)
@@ -74,6 +76,9 @@ class AssetFileClearerTest {
         hiddenFilesystemSupportFile.createNewFile()
         nestedFilesystemAssetFile = File("${filesystemSupportDir.absolutePath}/$assetName")
         nestedFilesystemAssetFile.createNewFile()
+
+        whenever(mockUlaFiles.filesDir).thenReturn(filesDir)
+        whenever(mockUlaFiles.busybox).thenReturn(topLevelSupportAssetFile)
     }
 
     @Test(expected = FileNotFoundException::class)

--- a/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
+++ b/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
@@ -238,4 +238,15 @@ class IllegalStateHandlerTest {
         val expectedResult = LocalizationData(resId, listOf())
         assertEquals(expectedResult, result)
     }
+
+    @Test
+    fun `BusyboxMissing returns correct id and strings`() {
+        val state = BusyboxMissing
+
+        val result = illegalStateHandler.getLocalizationData(state)
+
+        val resId = R.string.illegal_state_busybox_missing
+        val expectedResult = LocalizationData(resId, listOf())
+        assertEquals(expectedResult, result)
+    }
 }

--- a/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
+++ b/app/src/test/java/tech/ula/utils/IllegalStateHandlerTest.kt
@@ -119,6 +119,39 @@ class IllegalStateHandlerTest {
     }
 
     @Test
+    fun `LibFileNotFound returns correct id and strings`() {
+        val state = LibFileNotFound
+
+        val result = illegalStateHandler.getLocalizationData(state)
+
+        val resId = R.string.error_library_file_missing
+        val expectedResult = LocalizationData(resId, listOf())
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `LibDirNotFound returns correct id`() {
+        val state = LibDirNotFound
+
+        val result = illegalStateHandler.getLocalizationData(state)
+
+        val resId = R.string.error_no_lib_directory
+        val expectedResult = LocalizationData(resId, listOf())
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `ErrorSettingUpLinks returns correct id`() {
+        val state = ErrorSettingUpLinks
+
+        val result = illegalStateHandler.getLocalizationData(state)
+
+        val resId = R.string.error_library_setup_failure
+        val expectedResult = LocalizationData(resId, listOf())
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
     fun `ErrorFetchingAssetLists returns correct id and strings`() {
         val state = ErrorFetchingAssetLists
 


### PR DESCRIPTION
## What changes does this PR introduce?
Moves the symlinking of executables to a new step of session startup. Stops clearing the top-level support directory when clearing support assets.

## Any background context you want to provide?
Previously, we were just syncing executables during `MainActivity#onCreate`. This would cause issues if support assets were cleared, as the links wouldn't be recreated until the activity was recreated. There's also no point in clearing that directory as it assets won't be refetched from remote anymore.

## Where should the reviewer start?
Top-down: `MainActivity`
Bottom-up: `SessionStartupFsm`.

## Has this been manually tested? How?
Yes, tested both starting a session and clearing support files.

## What value does this provide to our end users?
Less breakage.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/8ccTGnPnbDyYo/giphy.gif)
