### PR TITLE
[Fix] VNC full screen not filling up entire screen

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -356,7 +356,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private fun getDeviceDimensions(session: Session) {
         val deviceDimensions = DeviceDimensions()
         val windowManager = applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-        deviceDimensions.getDeviceDimensions(windowManager, DisplayMetrics())
+
+        deviceDimensions.getDeviceDimensions(windowManager, DisplayMetrics(), applicationContext)
         session.geometry = deviceDimensions.getGeometry()
     }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -346,20 +346,20 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 sendXsdlIntentToSetDisplayNumberAndExpectResult()
             }
             "vnc" -> {
-                getDeviceDimensions(session)
+                setVncResolution(session)
                 startSession(session)
             }
             else -> startSession(session)
         }
     }
 
-    private fun getDeviceDimensions(session: Session) {
+    private fun setVncResolution(session: Session) {
         val deviceDimensions = DeviceDimensions()
         val windowManager = applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
         val orientation = applicationContext.resources.configuration.orientation
-        deviceDimensions.getDeviceDimensions(windowManager, DisplayMetrics(), orientation)
-        session.geometry = deviceDimensions.getGeometry()
+        deviceDimensions.saveDeviceDimensions(windowManager, DisplayMetrics(), orientation)
+        session.geometry = deviceDimensions.getScreenResolution()
     }
 
     private fun startSession(session: Session) {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -357,7 +357,8 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         val deviceDimensions = DeviceDimensions()
         val windowManager = applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
-        deviceDimensions.getDeviceDimensions(windowManager, DisplayMetrics(), applicationContext)
+        val orientation = applicationContext.resources.configuration.orientation
+        deviceDimensions.getDeviceDimensions(windowManager, DisplayMetrics(), orientation)
         session.geometry = deviceDimensions.getGeometry()
     }
 

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -417,7 +417,7 @@ class DeviceDimensions {
         display.getSize(appUsableSize)
         display.getRealSize(realScreenSize)
 
-        return Point(realScreenSize.x - appUsableSize.x, realScreenSize.y - appUsableSize. y)
+        return Point(realScreenSize.x - appUsableSize.x, realScreenSize.y - appUsableSize.y)
     }
 
     private fun checkOrientation(context: Context): String {

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -397,7 +397,7 @@ class DeviceDimensions {
         const val landscape = "SCREEN_ORIENTATION_LANDSCAPE"
     }
 
-    fun getDeviceDimensions(windowManager: WindowManager, displayMetrics: DisplayMetrics, orientation: Int) {
+    fun saveDeviceDimensions(windowManager: WindowManager, displayMetrics: DisplayMetrics, orientation: Int) {
         val navBarSize = getNavigationBarSize(windowManager)
         windowManager.defaultDisplay.getRealMetrics(displayMetrics)
         height = displayMetrics.heightPixels
@@ -427,7 +427,7 @@ class DeviceDimensions {
         }
     }
 
-    fun getGeometry(): String {
+    fun getScreenResolution(): String {
         return when (height > width) {
             true -> "${height}x$width"
             false -> "${width}x$height"

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -392,11 +392,6 @@ class DeviceDimensions {
     private var height = 720
     private var width = 1480
 
-    companion object {
-        const val portrait = "SCREEN_ORIENTATION_PORTRAIT"
-        const val landscape = "SCREEN_ORIENTATION_LANDSCAPE"
-    }
-
     fun saveDeviceDimensions(windowManager: WindowManager, displayMetrics: DisplayMetrics, orientation: Int) {
         val navBarSize = getNavigationBarSize(windowManager)
         windowManager.defaultDisplay.getRealMetrics(displayMetrics)
@@ -404,26 +399,10 @@ class DeviceDimensions {
         width = displayMetrics.widthPixels
         windowManager.defaultDisplay.getMetrics(displayMetrics)
 
-        when (checkOrientation(orientation)) {
-            portrait -> if (navBarSize.y > 0) height += navBarSize.y
-            landscape -> if (navBarSize.x > 0) width += navBarSize.x
-        }
-    }
-
-    private fun getNavigationBarSize(windowManager: WindowManager): Point {
-        val appUsableSize = Point()
-        val realScreenSize = Point()
-        val display = windowManager.defaultDisplay
-        display.getSize(appUsableSize)
-        display.getRealSize(realScreenSize)
-
-        return Point(realScreenSize.x - appUsableSize.x, realScreenSize.y - appUsableSize.y)
-    }
-
-    private fun checkOrientation(orientation: Int): String {
-        return when (orientation) {
-            Configuration.ORIENTATION_PORTRAIT -> portrait
-            else -> landscape
+        when (orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> if (navBarSize.y > 0) height += navBarSize.y
+            Configuration.ORIENTATION_LANDSCAPE -> if (navBarSize.x > 0) width += navBarSize.x
+            else -> return
         }
     }
 
@@ -432,6 +411,16 @@ class DeviceDimensions {
             true -> "${height}x$width"
             false -> "${width}x$height"
         }
+    }
+
+    private fun getNavigationBarSize(windowManager: WindowManager): Point {
+        val display = windowManager.defaultDisplay
+        val appSize = Point()
+        val screenSize = Point()
+        display.getSize(appSize)
+        display.getRealSize(screenSize)
+
+        return Point(screenSize.x - appSize.x, screenSize.y - appSize.y)
     }
 }
 

--- a/app/src/main/java/tech/ula/utils/AndroidUtility.kt
+++ b/app/src/main/java/tech/ula/utils/AndroidUtility.kt
@@ -397,14 +397,14 @@ class DeviceDimensions {
         const val landscape = "SCREEN_ORIENTATION_LANDSCAPE"
     }
 
-    fun getDeviceDimensions(windowManager: WindowManager, displayMetrics: DisplayMetrics, context: Context) {
+    fun getDeviceDimensions(windowManager: WindowManager, displayMetrics: DisplayMetrics, orientation: Int) {
         val navBarSize = getNavigationBarSize(windowManager)
         windowManager.defaultDisplay.getRealMetrics(displayMetrics)
         height = displayMetrics.heightPixels
         width = displayMetrics.widthPixels
         windowManager.defaultDisplay.getMetrics(displayMetrics)
 
-        when (checkOrientation(context)) {
+        when (checkOrientation(orientation)) {
             portrait -> if (navBarSize.y > 0) height += navBarSize.y
             landscape -> if (navBarSize.x > 0) width += navBarSize.x
         }
@@ -420,8 +420,8 @@ class DeviceDimensions {
         return Point(realScreenSize.x - appUsableSize.x, realScreenSize.y - appUsableSize.y)
     }
 
-    private fun checkOrientation(context: Context): String {
-        return when (context.resources.configuration.orientation) {
+    private fun checkOrientation(orientation: Int): String {
+        return when (orientation) {
             Configuration.ORIENTATION_PORTRAIT -> portrait
             else -> landscape
         }

--- a/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
+++ b/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
@@ -16,21 +16,21 @@ import org.mockito.junit.MockitoJUnitRunner
 class DeviceDimensionsTest {
 
     @Mock
-    lateinit var deviceDimensions: DeviceDimensions
+    lateinit var mockDeviceDimensions: DeviceDimensions
 
     @Mock
-    lateinit var windowManager: WindowManager
+    lateinit var mockWindowManager: WindowManager
 
     @Mock
-    lateinit var displayMetrics: DisplayMetrics
+    lateinit var mockDisplayMetrics: DisplayMetrics
 
     @Mock
-    lateinit var defaultDisplay: Display
+    lateinit var mockDisplay: Display
 
     @Before
     fun setup() {
-        deviceDimensions = DeviceDimensions()
-        whenever(windowManager.defaultDisplay).thenReturn(defaultDisplay)
+        mockDeviceDimensions = DeviceDimensions()
+        whenever(mockWindowManager.defaultDisplay).thenReturn(mockDisplay)
     }
 
     private fun setDimensions(displayMetrics: DisplayMetrics, width: Int, height: Int) {
@@ -40,17 +40,17 @@ class DeviceDimensionsTest {
 
     @Test
     fun `Device dimensions that are taller in height will have the height value first`() {
-        setDimensions(displayMetrics, width = 100, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, Configuration.ORIENTATION_PORTRAIT)
-        val geometry = deviceDimensions.getGeometry()
+        setDimensions(mockDisplayMetrics, width = 100, height = 200)
+        mockDeviceDimensions.saveDeviceDimensions(mockWindowManager, mockDisplayMetrics, Configuration.ORIENTATION_PORTRAIT)
+        val geometry = mockDeviceDimensions.getScreenResolution()
         assertEquals(geometry, "200x100")
     }
 
     @Test
     fun `Device dimensions that are longer in width will have the width value first`() {
-        setDimensions(displayMetrics, width = 300, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, Configuration.ORIENTATION_PORTRAIT)
-        val geometry = deviceDimensions.getGeometry()
+        setDimensions(mockDisplayMetrics, width = 300, height = 200)
+        mockDeviceDimensions.saveDeviceDimensions(mockWindowManager, mockDisplayMetrics, Configuration.ORIENTATION_PORTRAIT)
+        val geometry = mockDeviceDimensions.getScreenResolution()
         assertEquals(geometry, "300x200")
     }
 }

--- a/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
+++ b/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
@@ -1,12 +1,9 @@
 package tech.ula.utils
 
-import android.content.Context
 import android.content.res.Configuration
-import android.content.res.Resources
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
+++ b/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
@@ -1,9 +1,12 @@
 package tech.ula.utils
 
 import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -14,9 +17,6 @@ import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
 class DeviceDimensionsTest {
-
-    @Mock
-    lateinit var mockContext: Context
 
     @Mock
     lateinit var deviceDimensions: DeviceDimensions
@@ -44,7 +44,7 @@ class DeviceDimensionsTest {
     @Test
     fun `Device dimensions that are taller in height will have the height value first`() {
         setDimensions(displayMetrics, width = 100, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, mockContext)
+        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, Configuration.ORIENTATION_PORTRAIT)
         val geometry = deviceDimensions.getGeometry()
         assertEquals(geometry, "200x100")
     }
@@ -52,7 +52,7 @@ class DeviceDimensionsTest {
     @Test
     fun `Device dimensions that are longer in width will have the width value first`() {
         setDimensions(displayMetrics, width = 300, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, mockContext)
+        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, Configuration.ORIENTATION_PORTRAIT)
         val geometry = deviceDimensions.getGeometry()
         assertEquals(geometry, "300x200")
     }

--- a/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
+++ b/app/src/test/java/tech/ula/utils/DeviceDimensionsTest.kt
@@ -1,5 +1,6 @@
 package tech.ula.utils
 
+import android.content.Context
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
@@ -13,6 +14,9 @@ import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
 class DeviceDimensionsTest {
+
+    @Mock
+    lateinit var mockContext: Context
 
     @Mock
     lateinit var deviceDimensions: DeviceDimensions
@@ -40,7 +44,7 @@ class DeviceDimensionsTest {
     @Test
     fun `Device dimensions that are taller in height will have the height value first`() {
         setDimensions(displayMetrics, width = 100, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics)
+        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, mockContext)
         val geometry = deviceDimensions.getGeometry()
         assertEquals(geometry, "200x100")
     }
@@ -48,7 +52,7 @@ class DeviceDimensionsTest {
     @Test
     fun `Device dimensions that are longer in width will have the width value first`() {
         setDimensions(displayMetrics, width = 300, height = 200)
-        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics)
+        deviceDimensions.getDeviceDimensions(windowManager, displayMetrics, mockContext)
         val geometry = deviceDimensions.getGeometry()
         assertEquals(geometry, "300x200")
     }


### PR DESCRIPTION
## What changes does this PR introduce?
This PR introduces a fix for when the user starts a VNC session and the display doesn't utilize the entire device's screen.

This fix will address that by taking into account the navigation bar of the device.

## Any background context you want to provide?
This will only affect newly created filesystems.  Existing filesystems will have to edit their `~/.vncrc` and change their session resolution.

## Where should the reviewer start?
`UserLAnd/app/src/main/java/tech/ula/utils/AndroidUtility.kt` line 391 where `DeviceDimensions` is defined.

## Has this been manually tested? How?
Tested with all available devices in portrait and landscape mode

## What value does this provide to our end users?
Now the black bar on the left side of the screen shouldn't be there for newly created filesystems using vnc.


## Before
![Screenshot_20190620-081920](https://user-images.githubusercontent.com/11577853/59863295-49acef80-9339-11e9-87a5-8d637031a5bd.png)



## After
![Screenshot_20190620-084649](https://user-images.githubusercontent.com/11577853/59863192-110d1600-9339-11e9-862d-ac00d1e50019.png)




## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/POZulBhYwuOI2Dg7oX/giphy.gif)
