### PR TITLE
Rename scoped storage user directory to storage and reflect in binding.

### DIFF
--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -9,6 +9,7 @@ import android.provider.DocumentsContract.Document
 import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
 import tech.ula.R
+import tech.ula.utils.UlaFiles
 import tech.ula.utils.scopedStorageRoot
 import java.io.File
 import java.io.FileNotFoundException
@@ -33,6 +34,10 @@ class UlaDocProvider : DocumentsProvider() {
             Document.COLUMN_FLAGS,
             Document.COLUMN_SIZE
     )
+
+    private val ulaFiles by lazy {
+        UlaFiles(context!!.filesDir, context!!.scopedStorageRoot, File(context!!.applicationInfo.nativeLibraryDir))
+    }
 
     override fun onCreate(): Boolean { return true }
 
@@ -95,7 +100,7 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun addUlaRoots(result: MatrixCursor): Cursor {
-        val baseDir = File(context!!.scopedStorageRoot, "home")
+        val baseDir = ulaFiles.scopedUserDir
         result.newRow().apply {
             add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
             // Root for Ula storage should be the files dir

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -166,7 +166,7 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
                 "ROOT_PATH" to ulaFiles.filesDir.absolutePath,
                 "ROOTFS_PATH" to filesystemDir.absolutePath,
                 "PROOT_DEBUG_LEVEL" to prootDebugLevel,
-                "EXTRA_BINDINGS" to "-b ${ulaFiles.scopedUserDir.absolutePath}:/sdcard",
+                "EXTRA_BINDINGS" to "-b ${ulaFiles.scopedUserDir.absolutePath}:/storage",
                 "OS_VERSION" to System.getProperty("os.version")!!
         )
     }

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -11,7 +11,7 @@ class UlaFiles(
 ) {
 
     val supportDir: File = File(filesDir, "support")
-    val scopedUserDir: File = File(scopedDir, "home")
+    val scopedUserDir: File = File(scopedDir, "storage")
 
     init {
         scopedUserDir.mkdirs()


### PR DESCRIPTION
## What changes does this PR introduce?
Renames the user directory for scoped storage to "storage" and changes the PRoot binding to share the same name.

## Any background context you want to provide?
This will make the switch even more clear.

## Where should the reviewer start?
Anywhere it's like 3 lines.

## Has this been manually tested? How?
Yep, by creating a file using the new binding.

## What value does this provide to our end users?
Clarity.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/REGrSZ2B8jt9m/giphy.gif)
