### PR TITLE
Remove proot debug log export step.

### DIFF
--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -1,6 +1,5 @@
 package tech.ula.ui
 
-import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
@@ -9,16 +8,11 @@ import tech.ula.R
 import androidx.preference.PreferenceFragmentCompat
 import android.widget.Toast
 import androidx.preference.Preference
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import tech.ula.utils.ProotDebugLogger
 import tech.ula.utils.UlaFiles
 import tech.ula.utils.defaultSharedPreferences
 import tech.ula.utils.scopedStorageRoot
 import java.io.File
-import kotlin.coroutines.CoroutineContext
 
 class SettingsFragment : PreferenceFragmentCompat() {
 

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -6,7 +6,6 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import tech.ula.R
 import androidx.preference.PreferenceFragmentCompat
-import android.widget.Toast
 import androidx.preference.Preference
 import tech.ula.utils.ProotDebugLogger
 import tech.ula.utils.UlaFiles

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -20,32 +20,19 @@ import tech.ula.utils.scopedStorageRoot
 import java.io.File
 import kotlin.coroutines.CoroutineContext
 
-private const val EXPORT_REQUEST_CODE = 42
-
-class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
+class SettingsFragment : PreferenceFragmentCompat() {
 
     private val prootDebugLogger by lazy {
         val ulaFiles = UlaFiles(activity!!.filesDir, activity!!.scopedStorageRoot, File(activity!!.applicationInfo.nativeLibraryDir))
         ProotDebugLogger(activity!!.defaultSharedPreferences, ulaFiles)
     }
 
-    private val job = Job()
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + job
-
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences)
 
-        val exportFilePreference: Preference = findPreference("pref_proot_export_debug_file")!!
-        exportFilePreference.setOnPreferenceClickListener {
-            val intent = generateCreateIntent()
-            startActivityForResult(intent, EXPORT_REQUEST_CODE)
-            true
-        }
-
         val deleteFilePreference: Preference = findPreference("pref_proot_delete_debug_file")!!
         deleteFilePreference.setOnPreferenceClickListener {
-            prootDebugLogger.deleteLog()
+            prootDebugLogger.deleteLogs()
             Toast.makeText(activity, R.string.debug_log_deleted, Toast.LENGTH_LONG).show()
             true
         }
@@ -57,26 +44,5 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
 
     override fun setDividerHeight(height: Int) {
         super.setDividerHeight(0)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == EXPORT_REQUEST_CODE) {
-            data?.data?.let {
-                launch {
-                    val result = prootDebugLogger.copyLogToDestination(it, activity!!.contentResolver)
-                    if (result) Toast.makeText(activity, R.string.debug_log_export_success, Toast.LENGTH_LONG).show()
-                    else Toast.makeText(activity, R.string.debug_log_export_failure, Toast.LENGTH_LONG).show()
-                }
-            }
-        }
-    }
-
-    private fun generateCreateIntent(): Intent {
-        return Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-            addCategory(Intent.CATEGORY_OPENABLE)
-            type = "text/plain"
-            putExtra(Intent.EXTRA_TITLE, prootDebugLogger.logName)
-        }
     }
 }

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -27,7 +27,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val deleteFilePreference: Preference = findPreference("pref_proot_delete_debug_file")!!
         deleteFilePreference.setOnPreferenceClickListener {
             prootDebugLogger.deleteLogs()
-            Toast.makeText(activity, R.string.debug_log_deleted, Toast.LENGTH_LONG).show()
             true
         }
     }

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 
-class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, ulaFiles: UlaFiles) {
+class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, private val ulaFiles: UlaFiles) {
     private val prefs = defaultSharedPreferences
 
     val isEnabled: Boolean
@@ -19,7 +19,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, ulaFiles: Ul
     val verbosityLevel
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
-    val logName = "Proot_Debug_Log.txt"
+    private val logName = "Proot_Debug_Log.txt"
     private val logLocation = "${ulaFiles.scopedUserDir}/$logName"
 
     fun logStream(
@@ -39,20 +39,10 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, ulaFiles: Ul
         writer.close()
     }
 
-    suspend fun copyLogToDestination(uri: Uri, contentResolver: ContentResolver): Boolean = withContext(Dispatchers.IO) {
-        val logFile = File(logLocation)
-        try {
-            contentResolver.openOutputStream(uri, "w")?.use { outputStream ->
-                    outputStream.write(logFile.readText().toByteArray())
-            }
-            return@withContext true
-        } catch (err: Exception) {
-            return@withContext false
+    fun deleteLogs() {
+        val scopedFiles = ulaFiles.scopedUserDir.listFiles() ?: return
+        for (file in scopedFiles) {
+            if (file.name.contains(logName)) file.delete()
         }
-    }
-
-    fun deleteLog() {
-        val logFile = File(logLocation)
-        if (logFile.exists()) logFile.delete()
     }
 }

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -1,12 +1,8 @@
 package tech.ula.utils
 
-import android.content.ContentResolver
 import android.content.SharedPreferences
-import android.net.Uri
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,8 +155,7 @@
     <string name="pref_proot_debugging_level_title">Debug Verbosity Level</string>
     <string name="pref_proot_debugging_level_summary">The higher the number, the greater the verbosity.</string>
     <string name="pref_proot_debugging_level_default">-1</string>
-    <string name="pref_proot_export_debug_file_title">Export Debug File</string>
-    <string name="pref_proot_delete_debug_file_title">Delete Debug File</string>
+    <string name="pref_proot_delete_debug_file_title">Delete Old Debug Files</string>
 
     <!-- Help Activity -->
     <string name="github_message">Experiencing bugs or want to request a feature? Our Github page is the best place to go to get a fast response.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -35,11 +35,6 @@
             app:iconSpaceReserved="false"/>
         <Preference
             android:dependency="pref_proot_debug_enabled"
-            android:key="pref_proot_export_debug_file"
-            android:title="@string/pref_proot_export_debug_file_title"
-            app:iconSpaceReserved="false" />
-        <Preference
-            android:dependency="pref_proot_debug_enabled"
             android:key="pref_proot_delete_debug_file"
             android:title="@string/pref_proot_delete_debug_file_title"
             app:iconSpaceReserved="false"/>

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -25,10 +25,6 @@ class ProotDebugLoggerTest {
 
     @Mock lateinit var mockUlaFiles: UlaFiles
 
-    @Mock lateinit var mockContentResolver: ContentResolver
-
-    @Mock lateinit var mockUri: Uri
-
     private val logName = "Proot_Debug_Log.txt"
 
     private lateinit var prootDebugLogger: ProotDebugLogger
@@ -88,33 +84,15 @@ class ProotDebugLoggerTest {
     }
 
     @Test
-    fun `copyLogToDestination copies log to a URI-specified destination and returns true on success`() {
-        val originalText = "copy world"
-        val logFile = File(tempFolder.root, logName)
+    fun `deleteLogs deletes all files containing log name`() {
+        val logFile1 = File(tempFolder.root, "$logName-1")
+        val logFile2 = File(tempFolder.root, "$logName-2")
+        logFile1.createNewFile()
+        logFile2.createNewFile()
 
-        logFile.writeText(originalText)
+        prootDebugLogger.deleteLogs()
 
-        val destinationFile = File(tempFolder.root, "destination")
-
-        whenever(mockContentResolver.openOutputStream(mockUri, "w"))
-                .thenReturn(destinationFile.outputStream())
-
-        val result = runBlocking { prootDebugLogger.copyLogToDestination(mockUri, mockContentResolver) }
-
-        assertEquals(originalText, destinationFile.readText().trim())
-        assertTrue(result)
-    }
-
-    @Test
-    fun `copyLogToDestination returns false on failure if log file does not exist`() {
-        val destinationFile = File(tempFolder.root, "destination")
-
-        whenever(mockContentResolver.openOutputStream(mockUri, "w"))
-                .thenThrow(FileNotFoundException())
-
-        val result = runBlocking { prootDebugLogger.copyLogToDestination(mockUri, mockContentResolver) }
-
-        assertFalse(destinationFile.exists())
-        assertFalse(result)
+        assertFalse(logFile1.exists())
+        assertFalse(logFile2.exists())
     }
 }

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -1,8 +1,6 @@
 package tech.ula.utils
 
-import android.content.ContentResolver
 import android.content.SharedPreferences
-import android.net.Uri
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.* // ktlint-disable no-wildcard-imports
@@ -14,7 +12,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import java.io.File
-import java.io.FileNotFoundException
 
 @RunWith(MockitoJUnitRunner::class)
 class ProotDebugLoggerTest {


### PR DESCRIPTION
## What changes does this PR introduce?
Removes export step for proot debug and instead just continues writing it to user scoped storage.

## Any background context you want to provide?
This allows us to skip a step and will help users get used to the new file browser implementation.

## Where should the reviewer start?
Anywhere.

## Has this been manually tested? How?
By generating and deleting logs.

## What value does this provide to our end users?
See bg context.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/Y1W1LFJ4FXjnG/giphy.gif)
