### PR TITLE
 Fix bug that caused landing page to appear on rotation

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -31,7 +31,6 @@ import android.widget.Toast
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.navigation.findNavController
-import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.NavigationUI.setupWithNavController
 import kotlinx.android.synthetic.main.activity_main.* // ktlint-disable no-wildcard-imports

--- a/app/src/main/java/tech/ula/utils/QWarningHandler.kt
+++ b/app/src/main/java/tech/ula/utils/QWarningHandler.kt
@@ -24,7 +24,7 @@ class QWarningHandler(private val prefs: SharedPreferences, private val ulaFiles
     }
 
     private fun versionDoesNotMatchRequirement(): Boolean {
-        return prefs.getString(versionKey, "") ?: "" < "v2.1.5"
+        return prefs.getString(versionKey, "") ?: "" < "v2.6.0"
     }
 
     private fun userHasFilesystems(): Boolean {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,6 +25,8 @@
         android:orientation="vertical">
     </LinearLayout>
 
+    <!-- app:navGraph is defined dynamically so that startDestination can be defined dynamically
+    according to user preference -->
     <fragment
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -34,9 +36,7 @@
         app:layout_constraintBottom_toTopOf="@id/bottom_nav_view"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph" />
-
+        app:defaultNavHost="true" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_progress"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- app:navGraph is defined dynamically so that startDestination can be defined dynamically
+    according to user preference -->
 <navigation xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    app:startDestination="@id/app_list_fragment">
+    xmlns:tools="http://schemas.android.com/tools" >
     <fragment
         android:id="@+id/app_list_fragment"
         android:name="tech.ula.ui.AppListFragment"


### PR DESCRIPTION
## What changes does this PR introduce?
Fixes a recently introduced bug that would cause navigation to the landing page anytime `MainActivity` was recreated.

## Any background context you want to provide?
Statically setting the nav graph up causes this bug, because `startDestination` is set statically and then altered dynamically, instead of just being set the first time dynamically.

## Where should the reviewer start?
In any of the 3 files.

## Has this been manually tested? How?
Yes, by altering the preference and testing lifecycle/navigation.

## What value does this provide to our end users?
Eliminates an annoying bug.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/2t9mb0HwTVn3mHj8AZ/giphy.gif)
