### PR TITLE
Fix progress dialog displaying after session has started.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -360,6 +360,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     }
 
     private fun handleSessionHasBeenActivated() {
+        viewModel.handleSessionHasBeenActivated()
         killProgressBar()
     }
 

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -220,9 +220,6 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
         super.onResume()
 
         viewModel.handleOnResume()
-        val intent = Intent(this, ServerService::class.java)
-                .putExtra("type", "isProgressBarActive")
-        this.startService(intent)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -271,6 +271,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
 
     private fun handleStateUpdate(newState: State) {
         return when (newState) {
+            is WaitingForInput -> { killProgressBar() }
             is CanOnlyStartSingleSession -> { showToast(R.string.single_session_supported) }
             is SessionCanBeStarted -> { prepareSessionForStart(newState.session) }
             is SessionCanBeRestarted -> { restartRunningSession(newState.session) }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -41,7 +41,9 @@ class MainActivityViewModel(
 
     private val sessionState = sessionStartupFsm.getState()
 
-    private val state = MediatorLiveData<State>()
+    private val state = MediatorLiveData<State>().apply {
+        postValue(WaitingForInput)
+    }
 
     private fun postIllegalStateWithLog(newState: IllegalState) {
         logger.sendIllegalStateLog(newState)

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -372,7 +372,7 @@ class MainActivityViewModel(
         return when (newState) {
             is ExtractingFilesystem -> state.postValue(FilesystemExtractionStep(newState.extractionTarget))
             is ExtractionHasCompletedSuccessfully -> { doTransitionIfRequirementsAreSelected {
-                state.value = SessionCanBeStarted(lastSelectedSession)
+                state.postValue(SessionCanBeStarted(lastSelectedSession))
             } }
             is ExtractionFailed -> postIllegalStateWithLog(FailedToExtractFilesystem(newState.reason))
         }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -366,7 +366,7 @@ class MainActivityViewModel(
         return when (newState) {
             is ExtractingFilesystem -> state.postValue(FilesystemExtractionStep(newState.extractionTarget))
             is ExtractionHasCompletedSuccessfully -> { doTransitionIfRequirementsAreSelected {
-                state.postValue(SessionCanBeStarted(lastSelectedSession))
+                state.value = SessionCanBeStarted(lastSelectedSession)
                 resetStartupState()
             } }
             is ExtractionFailed -> postIllegalStateWithLog(FailedToExtractFilesystem(newState.reason))
@@ -377,6 +377,7 @@ class MainActivityViewModel(
         lastSelectedApp = unselectedApp
         lastSelectedSession = unselectedSession
         lastSelectedFilesystem = unselectedFilesystem
+        state.postValue(WaitingForInput)
         submitAppsStartupEvent(ResetAppState)
         submitSessionStartupEvent(ResetSessionState)
     }
@@ -415,6 +416,7 @@ class MainActivityViewModel(
 }
 
 sealed class State
+object WaitingForInput : State()
 object CanOnlyStartSingleSession : State()
 data class SessionCanBeStarted(val session: Session) : State()
 data class SessionCanBeRestarted(val session: Session) : State()

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -164,6 +164,10 @@ class MainActivityViewModel(
         submitSessionStartupEvent(DownloadAssets(downloadRequirements))
     }
 
+    fun handleSessionHasBeenActivated() {
+        resetStartupState()
+    }
+
     suspend fun handleClearSupportFiles(assetFileClearer: AssetFileClearer) {
         if (sessionStartupFsm.sessionsAreActive()) {
             state.postValue(ActiveSessionsMustBeDeactivated)
@@ -367,7 +371,6 @@ class MainActivityViewModel(
             is ExtractingFilesystem -> state.postValue(FilesystemExtractionStep(newState.extractionTarget))
             is ExtractionHasCompletedSuccessfully -> { doTransitionIfRequirementsAreSelected {
                 state.value = SessionCanBeStarted(lastSelectedSession)
-                resetStartupState()
             } }
             is ExtractionFailed -> postIllegalStateWithLog(FailedToExtractFilesystem(newState.reason))
         }

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -240,6 +240,7 @@ class MainActivityViewModelTest {
         assertEquals(mainActivityViewModel.lastSelectedFilesystem, unselectedFilesystem)
 
         runBlocking {
+            verify(mockStateObserver).onChanged(WaitingForInput)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
         }
@@ -664,6 +665,7 @@ class MainActivityViewModelTest {
         assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
         assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
         runBlocking {
+            verify(mockStateObserver).onChanged(WaitingForInput)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
         }
@@ -764,6 +766,7 @@ class MainActivityViewModelTest {
         assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
         assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
         runBlocking {
+            verify(mockStateObserver).onChanged(WaitingForInput)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
         }

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -84,8 +84,8 @@ class MainActivityViewModelTest {
     }
 
     @Test
-    fun `State does not initially publish onChanged event`() {
-        verify(mockStateObserver, never()).onChanged(any())
+    fun `State is initially WaitingForInput`() {
+        verify(mockStateObserver).onChanged(WaitingForInput)
     }
 
     @Test

--- a/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/tech/ula/viewmodel/MainActivityViewModelTest.kt
@@ -240,7 +240,7 @@ class MainActivityViewModelTest {
         assertEquals(mainActivityViewModel.lastSelectedFilesystem, unselectedFilesystem)
 
         runBlocking {
-            verify(mockStateObserver).onChanged(WaitingForInput)
+            verify(mockStateObserver, times(2)).onChanged(WaitingForInput)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
         }
@@ -277,7 +277,7 @@ class MainActivityViewModelTest {
         assertEquals(mainActivityViewModel.lastSelectedSession, unselectedSession)
         assertEquals(mainActivityViewModel.lastSelectedFilesystem, unselectedFilesystem)
 
-        verify(mockStateObserver).onChanged(WaitingForInput)
+        verify(mockStateObserver, times(2)).onChanged(WaitingForInput)
         runBlocking {
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
@@ -684,7 +684,7 @@ class MainActivityViewModelTest {
         assertEquals(unselectedSession, mainActivityViewModel.lastSelectedSession)
         assertEquals(unselectedFilesystem, mainActivityViewModel.lastSelectedFilesystem)
         runBlocking {
-            verify(mockStateObserver).onChanged(WaitingForInput)
+            verify(mockStateObserver, times(2)).onChanged(WaitingForInput)
             verify(mockSessionStartupFsm).submitEvent(ResetSessionState, mainActivityViewModel)
             verify(mockAppsStartupFsm).submitEvent(ResetAppState, mainActivityViewModel)
         }


### PR DESCRIPTION
## What changes does this PR introduce?
This PR adds a state to the main VM called `WaitingForInput` that is entered when startup state is reset.

## Any background context you want to provide?
There was a bug that's been around for a while that would cause the progress dialog to reappear during rotation after a session has been started. It occurred because of the following flow

- Rotation causes activity destruction and recreation
- Activity subscribes to events from the VM
- Last emitted state from VM is that extraction happened successfully
- Activity thinks this means it's time to start the session
- Tries restarting session and re-displays progress dialog

This is now being avoided by making the VM aware of when sessions are actually activated, so that it's most recent emitted state becomes `WaitingForInput` instead.

## Where should the reviewer start?
`MainActivity` or the VM.

## Has this been manually tested? How?
Yes, by starting sessions on existing and new filesystems and rotating afterwards.

## What value does this provide to our end users?
Another bug fix.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/aaODAv1iuQdgI/giphy.gif)
