### PR TITLE
Fix bug causing progress dialog to not be updated when proot debug logging.

### DIFF
--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -93,10 +93,14 @@ class BusyboxExecutor(
             val process = processBuilder.start()
             when {
                 prootDebugEnabled && commandShouldTerminate -> {
+                    // Call the listener explicitly since all output will be captured by the log
+                    listener("Output redirecting to proot debug log")
                     prootDebugLogger.logStream(process.inputStream, coroutineScope)
                     getProcessResult(process)
                 }
                 prootDebugEnabled && !commandShouldTerminate -> {
+                    // Call the listener explicitly since all output will be captured by the log
+                    listener("Output redirecting to proot debug log")
                     prootDebugLogger.logStream(process.inputStream, coroutineScope)
                     OngoingExecution(process)
                 }

--- a/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
+++ b/app/src/test/java/tech/ula/utils/BusyboxExecutorTest.kt
@@ -214,7 +214,7 @@ class BusyboxExecutorTest {
         }
 
         assertTrue(result is SuccessfulExecution)
-        assertEquals(0, outputCollection.size)
+        assertEquals(1, outputCollection.size)
         verify(mockProotDebugLogger).logStream(any(), any())
     }
 


### PR DESCRIPTION
## What changes does this PR introduce?
Fixes a bug where "Verifying Assets" would be displayed during the entire extraction step while proot debug logging was enabled.

## Any background context you want to provide?
Nah

## Where should the reviewer start?
It's one line

## Has this been manually tested? How?
Yes, by doing it

## What value does this provide to our end users?
Clarity

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/Hw5wyPEsNgxc4/giphy.gif)
