### PR TITLE
Fix iilegal state transition when downloads fail by cancelling downloads.

### DIFF
--- a/app/src/main/java/tech/ula/utils/AssetDownloader.kt
+++ b/app/src/main/java/tech/ula/utils/AssetDownloader.kt
@@ -75,6 +75,7 @@ class AssetDownloader(
 
         if (downloadManagerWrapper.downloadHasFailed(downloadId)) {
             val reason = downloadManagerWrapper.getDownloadFailureReason(downloadId)
+            downloadManagerWrapper.cancelAllDownloads(enqueuedDownloadIds)
             return AssetDownloadFailure(reason)
         }
 
@@ -227,6 +228,10 @@ class DownloadManagerWrapper(private val downloadManager: DownloadManager) {
             }, formatStrings = listOf("$status")) // Format strings only used for http_error
         }
         return DownloadFailureLocalizationData(R.string.download_failure_reason_not_found)
+    }
+
+    fun cancelAllDownloads(downloadIds: Set<Long>) {
+        downloadManager.remove(*downloadIds.toLongArray())
     }
 }
 

--- a/app/src/test/java/tech/ula/utils/AssetDownloaderTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetDownloaderTest.kt
@@ -133,6 +133,7 @@ class AssetDownloaderTest {
         assertTrue(result is AssetDownloadFailure)
         val cast = result as AssetDownloadFailure
         assertEquals(failureReason, cast.reason)
+        verify(downloadManagerWrapper).cancelAllDownloads(setOf(0))
     }
 
     @Test


### PR DESCRIPTION
## What changes does this PR introduce?
Fixes a Sentry issue by cancelling downloads when one fails. 

## Any background context you want to provide?
This issue was caused when `AssetDownloadComplete` events were submitted to the session FSM while it was in the `AssetDownloadFailure` state.

## Where should the reviewer start?
`AssetDownloader`

## Has this been manually tested? How?
No, because it's hard to manipulate the app into this state. Instead I'll just keep an eye on Sentry.

## What value does this provide to our end users?
Less illegal state messages.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/ryByff5GXqz8A/giphy.gif)
