### PR TITLE
Fix bug where running sessions could not be accessed.

### DIFF
--- a/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
+++ b/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
@@ -18,7 +18,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.platform.app.InstrumentationRegistry
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
-import androidx.test.espresso.ViewAssertion
 import java.io.File
 import java.util.concurrent.TimeoutException
 

--- a/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
+++ b/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
@@ -18,6 +18,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.platform.app.InstrumentationRegistry
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
+import androidx.test.espresso.ViewAssertion
 import java.io.File
 import java.util.concurrent.TimeoutException
 
@@ -94,6 +95,9 @@ fun @receiver:StringRes Int.matchText(): ViewInteraction =
 // TODO this doesn't quite work. will be useful for failure tests
 fun @receiver:StringRes Int.notDisplayedInToast(): ViewInteraction =
         this.matchText().inRoot(ToastMatcher()).check(ViewAssertions.doesNotExist())
+
+fun @receiver:StringRes Int.displayedInToast(): ViewInteraction =
+        this.matchText().inRoot(ToastMatcher()).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
 fun String.enterAsNativeViewText() {
     val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())

--- a/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
@@ -1,11 +1,14 @@
 package tech.ula.ui
 
 import android.Manifest
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertDisplayedAtPosition
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogPositiveButton
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.schibsted.spain.barista.interaction.BaristaListInteractions.clickListItem
@@ -93,6 +96,31 @@ class MainActivityTest {
         for (file in expectedStatusFiles) {
             waitForFile(file, timeout = 60_000)
         }
+
+        // Return to apps list
+        Espresso.closeSoftKeyboard()
+        Espresso.pressBack()
+        R.id.app_list_fragment.shortWaitForDisplay()
+
+        // Try to start a second session
+        clickListItem(R.id.list_apps, 1)
+        // Set up second session
+        R.string.filesystem_credentials_reasoning.waitForDisplay()
+        writeTo(R.id.text_input_username, username)
+        writeTo(R.id.text_input_password, sshPassword)
+        writeTo(R.id.text_input_vnc_password, vncPassword)
+        clickDialogPositiveButton()
+        R.string.prompt_app_connection_type_preference.shortWaitForDisplay()
+        clickRadioButtonItem(R.id.radio_apps_service_type_preference, R.id.ssh_radio_button)
+        clickDialogPositiveButton()
+        // Asset second session cannot be started
+        assertNotDisplayed(R.id.progress_bar_session_list)
+        R.string.single_session_supported.displayedInToast()
+
+        // Assert session can be restarted
+        clickListItem(R.id.list_apps, 0)
+        assertNotDisplayed(R.id.layout_progress)
+        R.id.terminal_view.shortWaitForDisplay()
     }
 
     private fun doHappyPathTestScript(): List<File> {

--- a/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
@@ -7,7 +7,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertDisplayedAtPosition
-import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogPositiveButton
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -273,7 +273,10 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private fun handleStateUpdate(newState: State) {
         return when (newState) {
             is WaitingForInput -> { killProgressBar() }
-            is CanOnlyStartSingleSession -> { showToast(R.string.single_session_supported) }
+            is CanOnlyStartSingleSession -> {
+                showToast(R.string.single_session_supported)
+                viewModel.handleUserInputCancelled()
+            }
             is SessionCanBeStarted -> { prepareSessionForStart(newState.session) }
             is SessionCanBeRestarted -> { restartRunningSession(newState.session) }
             is IllegalState -> { handleIllegalState(newState) }

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -255,7 +255,6 @@ class MainActivityViewModel(
             }
             is SessionIsRestartable -> {
                 state.postValue(SessionCanBeRestarted(newState.session))
-                resetStartupState()
             }
             is SessionIsReadyForPreparation -> {
                 lastSelectedSession = newState.session

--- a/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/MainActivityViewModel.kt
@@ -251,7 +251,6 @@ class MainActivityViewModel(
             }
             is SingleSessionSupported -> {
                 state.postValue(CanOnlyStartSingleSession)
-                resetStartupState()
             }
             is SessionIsRestartable -> {
                 state.postValue(SessionCanBeRestarted(newState.session))


### PR DESCRIPTION
## What changes does this PR introduce?
Fixes recently two recently introduced bugs
- Sessions could not be restarted
- Users would not receive message about only supporting single sessions

I also went ahead and added regressions to our end-to-end test for this bug.

## Any background context you want to provide?
`MutableLiveData#postValue` only dispatches the latest event to an observer _when the observer requests it_, so the events that should have been observed to obtain desired behavior were being overwritten by the resetting of startup state events. 

## Where should the reviewer start?
`MainActivityViewModel`

## Has this been manually tested? How?
Yes, by trying both cases and observing end-to-end test.

## What value does this provide to our end users?
Correct behavior.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/sChf4Eo55W8x2/giphy.gif)
