### PR TITLE
Add an sdcard scoped storage binding.

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
-    private val ulaFiles by lazy { UlaFiles(this) }
+    private val ulaFiles by lazy { UlaFiles(this, this.applicationInfo.nativeLibraryDir) }
     private val busyboxExecutor by lazy {
         val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
     private var currentFragmentDisplaysProgressDialog = false
 
     private val logger = SentryLogger()
-    private val ulaFiles by lazy { UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir)) }
+    private val ulaFiles by lazy { UlaFiles(this) }
     private val busyboxExecutor by lazy {
         val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)

--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -50,7 +50,6 @@ import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 import tech.ula.ui.FilesystemListFragment
 import tech.ula.model.repositories.DownloadMetadata
 import tech.ula.utils.preferences.* // ktlint-disable no-wildcard-imports
-import java.io.File
 
 class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, AppsListFragment.AppSelection, FilesystemListFragment.FilesystemListProgress {
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -15,7 +15,6 @@ import tech.ula.model.entities.ServiceType
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.model.entities.Session
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
-import java.io.File
 
 class ServerService : Service() {
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -32,7 +32,7 @@ class ServerService : Service() {
     }
 
     private val busyboxExecutor by lazy {
-        val ulaFiles = UlaFiles(this)
+        val ulaFiles = UlaFiles(this, this.applicationInfo.nativeLibraryDir)
         val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -32,7 +32,7 @@ class ServerService : Service() {
     }
 
     private val busyboxExecutor by lazy {
-        val ulaFiles = UlaFiles(this.filesDir, this.scopedStorageRoot, File(this.applicationInfo.nativeLibraryDir))
+        val ulaFiles = UlaFiles(this)
         val prootDebugLogger = ProotDebugLogger(this.defaultSharedPreferences, ulaFiles)
         BusyboxExecutor(ulaFiles, prootDebugLogger)
     }

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -10,7 +10,6 @@ import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
 import tech.ula.R
 import tech.ula.utils.UlaFiles
-import tech.ula.utils.scopedStorageRoot
 import java.io.File
 import java.io.FileNotFoundException
 import java.lang.Exception
@@ -36,7 +35,7 @@ class UlaDocProvider : DocumentsProvider() {
     )
 
     private val ulaFiles by lazy {
-        UlaFiles(context!!.filesDir, context!!.scopedStorageRoot, File(context!!.applicationInfo.nativeLibraryDir))
+        UlaFiles(context!!)
     }
 
     override fun onCreate(): Boolean { return true }
@@ -100,7 +99,7 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun addUlaRoots(result: MatrixCursor): Cursor {
-        val baseDir = ulaFiles.scopedUserDir
+        val baseDir = ulaFiles.emulatedUserDir
         result.newRow().apply {
             add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
             // Root for Ula storage should be the files dir

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -99,17 +99,31 @@ class UlaDocProvider : DocumentsProvider() {
     }
 
     private fun addUlaRoots(result: MatrixCursor): Cursor {
-        val baseDir = ulaFiles.emulatedUserDir
+        val baseEmulatedDir = ulaFiles.emulatedUserDir
         result.newRow().apply {
-            add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name))
+            add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name) + " INTERNAL")
             // Root for Ula storage should be the files dir
-            add(Root.COLUMN_ROOT_ID, getDocIdForFile(baseDir))
-            add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(baseDir))
+            add(Root.COLUMN_ROOT_ID, getDocIdForFile(baseEmulatedDir))
+            add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(baseEmulatedDir))
 
             // Allow creation and searching
             add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE)
             add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
-            add(Root.COLUMN_AVAILABLE_BYTES, baseDir.freeSpace)
+            add(Root.COLUMN_AVAILABLE_BYTES, baseEmulatedDir.freeSpace)
+        }
+        val baseSdCardDir = ulaFiles.sdCardUserDir
+        baseSdCardDir?.let {
+            result.newRow().apply {
+                add(Root.COLUMN_TITLE, context!!.getString(R.string.app_name) + " SDCARD")
+                // Root for Ula storage should be the files dir
+                add(Root.COLUMN_ROOT_ID, getDocIdForFile(baseSdCardDir))
+                add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(baseSdCardDir))
+
+                // Allow creation and searching
+                add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE)
+                add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+                add(Root.COLUMN_AVAILABLE_BYTES, baseSdCardDir.freeSpace)
+            }
         }
         return result
     }

--- a/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
+++ b/app/src/main/java/tech/ula/provider/UlaDocProvider.kt
@@ -35,7 +35,7 @@ class UlaDocProvider : DocumentsProvider() {
     )
 
     private val ulaFiles by lazy {
-        UlaFiles(context!!)
+        UlaFiles(context!!, context!!.applicationInfo.nativeLibraryDir)
     }
 
     override fun onCreate(): Boolean { return true }

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -43,7 +43,7 @@ class FilesystemListFragment : Fragment() {
         val filesystemDao = UlaDatabase.getInstance(activityContext).filesystemDao()
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
 
-        val ulaFiles = UlaFiles(activityContext)
+        val ulaFiles = UlaFiles(activityContext, activityContext.applicationInfo.nativeLibraryDir)
         val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, ulaFiles)
         val busyboxExecutor = BusyboxExecutor(ulaFiles, prootDebugLogger)
 

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -21,7 +21,6 @@ import tech.ula.viewmodel.* // ktlint-disable no-wildcard-imports
 import tech.ula.model.entities.Session
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
 import tech.ula.viewmodel.FilesystemListViewModel
-import java.io.File
 
 private const val FILESYSTEM_EXPORT_REQUEST_CODE = 7
 

--- a/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
+++ b/app/src/main/java/tech/ula/ui/FilesystemListFragment.kt
@@ -43,7 +43,7 @@ class FilesystemListFragment : Fragment() {
         val filesystemDao = UlaDatabase.getInstance(activityContext).filesystemDao()
         val sessionDao = UlaDatabase.getInstance(activityContext).sessionDao()
 
-        val ulaFiles = UlaFiles(activityContext.filesDir, activityContext.scopedStorageRoot, File(activityContext.applicationInfo.nativeLibraryDir))
+        val ulaFiles = UlaFiles(activityContext)
         val prootDebugLogger = ProotDebugLogger(activityContext.defaultSharedPreferences, ulaFiles)
         val busyboxExecutor = BusyboxExecutor(ulaFiles, prootDebugLogger)
 

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -10,13 +10,11 @@ import androidx.preference.Preference
 import tech.ula.utils.ProotDebugLogger
 import tech.ula.utils.UlaFiles
 import tech.ula.utils.defaultSharedPreferences
-import tech.ula.utils.scopedStorageRoot
-import java.io.File
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
     private val prootDebugLogger by lazy {
-        val ulaFiles = UlaFiles(activity!!.filesDir, activity!!.scopedStorageRoot, File(activity!!.applicationInfo.nativeLibraryDir))
+        val ulaFiles = UlaFiles(activity!!)
         ProotDebugLogger(activity!!.defaultSharedPreferences, ulaFiles)
     }
 

--- a/app/src/main/java/tech/ula/ui/SettingsFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SettingsFragment.kt
@@ -14,7 +14,7 @@ import tech.ula.utils.defaultSharedPreferences
 class SettingsFragment : PreferenceFragmentCompat() {
 
     private val prootDebugLogger by lazy {
-        val ulaFiles = UlaFiles(activity!!)
+        val ulaFiles = UlaFiles(activity!!, activity!!.applicationInfo.nativeLibraryDir)
         ProotDebugLogger(activity!!.defaultSharedPreferences, ulaFiles)
     }
 

--- a/app/src/main/java/tech/ula/utils/AssetDownloader.kt
+++ b/app/src/main/java/tech/ula/utils/AssetDownloader.kt
@@ -26,7 +26,7 @@ class AssetDownloader(
     private val ulaFiles: UlaFiles
 ) {
 
-    private val downloadDirectory = File(ulaFiles.scopedDir, "downloads")
+    private val downloadDirectory = File(ulaFiles.emulatedScopedDir, "downloads")
 
     private val enqueuedDownloadIds = mutableSetOf<Long>()
     private val completedDownloadIds = mutableSetOf<Long>()

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -164,13 +164,18 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
     }
 
     fun getProotEnv(filesystemDir: File, prootDebugLevel: String): HashMap<String, String> {
+        val emulatedStorageBinding = "-b ${ulaFiles.emulatedUserDir.absolutePath}:/storage/emulated"
+        val externalStorageBinding = ulaFiles.sdCardUserDir?.run {
+            "-b ${this.absolutePath}:/storage/external"
+        } ?: ""
+        val bindings = "$emulatedStorageBinding $externalStorageBinding"
         return hashMapOf(
                 "LD_LIBRARY_PATH" to ulaFiles.supportDir.absolutePath,
                 "LIB_PATH" to ulaFiles.supportDir.absolutePath,
                 "ROOT_PATH" to ulaFiles.filesDir.absolutePath,
                 "ROOTFS_PATH" to filesystemDir.absolutePath,
                 "PROOT_DEBUG_LEVEL" to prootDebugLevel,
-                "EXTRA_BINDINGS" to "-b ${ulaFiles.scopedUserDir.absolutePath}:/storage",
+                "EXTRA_BINDINGS" to bindings,
                 "OS_VERSION" to System.getProperty("os.version")!!
         )
     }

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -196,9 +196,8 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
         // If users upgraded from a version 2.5.14 - 2.6.1, the storage directory will exist but
         // with unusable permissions. It needs to be recreated.
         val storageBindingDir = File(filesystemDir, "storage")
-        if (storageBindingDir.exists() &&
-                storageBindingDir.isDirectory &&
-                storageBindingDir.listFiles()?.isEmpty() == true) {
+        val storageBindingDirEmpty = storageBindingDir.listFiles()?.isEmpty() ?: true
+        if (storageBindingDir.exists() && storageBindingDir.isDirectory && storageBindingDirEmpty) {
             storageBindingDir.delete()
         }
         storageBindingDir.mkdirs()
@@ -206,9 +205,8 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
         // If users upgraded from a version before 2.5.14, the old sdcard binding should be removed
         // to increase clarity.
         val sdCardBindingDir = File(filesystemDir, "sdcard")
-        if (sdCardBindingDir.exists() &&
-                sdCardBindingDir.isDirectory &&
-                sdCardBindingDir.listFiles()?.isEmpty() == true) {
+        val sdCardBindingDirEmpty = sdCardBindingDir.listFiles()?.isEmpty() ?: true
+        if (sdCardBindingDir.exists() && sdCardBindingDir.isDirectory && sdCardBindingDirEmpty) {
             sdCardBindingDir.delete()
         }
     }

--- a/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
+++ b/app/src/main/java/tech/ula/utils/BusyboxExecutor.kt
@@ -164,9 +164,9 @@ class BusyboxWrapper(private val ulaFiles: UlaFiles) {
     }
 
     fun getProotEnv(filesystemDir: File, prootDebugLevel: String): HashMap<String, String> {
-        val emulatedStorageBinding = "-b ${ulaFiles.emulatedUserDir.absolutePath}:/storage/emulated"
+        val emulatedStorageBinding = "-b ${ulaFiles.emulatedUserDir.absolutePath}:/emulated"
         val externalStorageBinding = ulaFiles.sdCardUserDir?.run {
-            "-b ${this.absolutePath}:/storage/external"
+            "-b ${this.absolutePath}:/external"
         } ?: ""
         val bindings = "$emulatedStorageBinding $externalStorageBinding"
         return hashMapOf(

--- a/app/src/main/java/tech/ula/utils/Extensions.kt
+++ b/app/src/main/java/tech/ula/utils/Extensions.kt
@@ -9,7 +9,6 @@ import androidx.annotation.IdRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import tech.ula.R
-import java.io.File
 
 fun <A, B> zipLiveData(a: LiveData<A>, b: LiveData<B>): LiveData<Pair<A, B>> {
     return MediatorLiveData<Pair<A, B>>().apply {

--- a/app/src/main/java/tech/ula/utils/Extensions.kt
+++ b/app/src/main/java/tech/ula/utils/Extensions.kt
@@ -46,13 +46,6 @@ fun Context.displayGenericErrorDialog(titleId: Int, messageId: Int, callback: ((
             .create().show()
 }
 
-inline val Context.scopedStorageRoot: File
-    get() = this.getExternalFilesDir(null) ?: run {
-        val scopedStorageRoot = File(this.filesDir, "storage")
-        scopedStorageRoot.mkdirs()
-        scopedStorageRoot
-    }
-
 inline val Context.defaultSharedPreferences: SharedPreferences
     get() = this.getSharedPreferences("${this.packageName}_preferences", Context.MODE_PRIVATE)
 

--- a/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
+++ b/app/src/main/java/tech/ula/utils/ProotDebugLogger.kt
@@ -16,7 +16,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, private val 
         get() = prefs.getString("pref_proot_debug_level", "-1") ?: "-1"
 
     private val logName = "Proot_Debug_Log.txt"
-    private val logLocation = "${ulaFiles.scopedUserDir}/$logName"
+    private val logLocation = "${ulaFiles.emulatedUserDir}/$logName"
 
     fun logStream(
         inputStream: InputStream,
@@ -36,7 +36,7 @@ class ProotDebugLogger(defaultSharedPreferences: SharedPreferences, private val 
     }
 
     fun deleteLogs() {
-        val scopedFiles = ulaFiles.scopedUserDir.listFiles() ?: return
+        val scopedFiles = ulaFiles.emulatedUserDir.listFiles() ?: return
         for (file in scopedFiles) {
             if (file.name.contains(logName)) file.delete()
         }

--- a/app/src/main/java/tech/ula/utils/UlaFiles.kt
+++ b/app/src/main/java/tech/ula/utils/UlaFiles.kt
@@ -7,11 +7,12 @@ import java.lang.NullPointerException
 
 class UlaFiles(
     context: Context,
+    libDirPath: String,
     private val symlinker: Symlinker = Symlinker()
 ) {
 
     val filesDir: File = context.filesDir
-    val libDir: File = File(context.applicationInfo.nativeLibraryDir)
+    val libDir: File = File(libDirPath)
     val supportDir: File = File(filesDir, "support")
     val emulatedScopedDir = context.getExternalFilesDir(null)!!
     val emulatedUserDir = File(emulatedScopedDir, "storage")

--- a/app/src/test/java/tech/ula/utils/AssetDownloaderTest.kt
+++ b/app/src/test/java/tech/ula/utils/AssetDownloaderTest.kt
@@ -65,7 +65,7 @@ class AssetDownloaderTest {
         mockFilesDir = tempFolder.newFolder("files")
         mockScopedStorageDir = tempFolder.newFolder("scoped")
         whenever(mockUlaFiles.filesDir).thenReturn(mockFilesDir)
-        whenever(mockUlaFiles.scopedDir).thenReturn(mockScopedStorageDir)
+        whenever(mockUlaFiles.emulatedScopedDir).thenReturn(mockScopedStorageDir)
 
         downloadDirectory = File(mockScopedStorageDir, "downloads")
         downloadDirectory.mkdirs()

--- a/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
+++ b/app/src/test/java/tech/ula/utils/ProotDebugLoggerTest.kt
@@ -28,7 +28,7 @@ class ProotDebugLoggerTest {
 
     @Before
     fun setup() {
-        whenever(mockUlaFiles.scopedUserDir).thenReturn(tempFolder.root)
+        whenever(mockUlaFiles.emulatedUserDir).thenReturn(tempFolder.root)
 
         prootDebugLogger = ProotDebugLogger(mockDefaultSharedPreferences, mockUlaFiles)
     }


### PR DESCRIPTION
## What changes does this PR introduce?
This changes the bindings from 
- `/storage` in session binding to `<actual scoped emulated storage>/storage`

to
- `/storage/internal` in session binding to `<actual scoped emulated strorage>/storage`
-`/storage/sdcard` in session binding to `<actual scoped sdcard storage>/storage`.

Note that the sdcard binding will only be present in the case of an actual physical card being present on the device.

It also updates the document provider to have a link sdcard scoped storage if it's present.

I'll update the wiki tomorrow, 7/31, so hold off on merging until then.

## Any background context you want to provide?
Inspired by and closes #937.

## Where should the reviewer start?
`BusyboxExecutor`

## Has this been manually tested? How?
Yes, in the usual ways. Files also persist through upgrades.

## What value does this provide to our end users?
Greater device access.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/RJbU9sV2oAtQ2tH8UU/giphy.gif)
