### PR TITLE
Fix launching into VNC sessions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode vcode
-        versionName "2.6.1"
+        versionName "2.6.2"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'

--- a/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
@@ -114,6 +114,7 @@ class AppsStartupFsm(
 
     private suspend fun setServiceType(appSession: Session, serviceType: ServiceType) = withContext(Dispatchers.IO) {
         appSession.serviceType = serviceType
+        appSession.port = if (serviceType == ServiceType.Ssh) 2022 else 51
         sessionDao.updateSession(appSession)
         state.postValue(AppHasServiceTypeSet)
     }
@@ -156,6 +157,8 @@ class AppsStartupFsm(
         state.postValue(SyncingDatabaseEntries)
         appSession.filesystemId = appsFilesystem.id
         appSession.filesystemName = appsFilesystem.name
+        appSession.serviceType = appSession.serviceType
+        appSession.port = if (appSession.serviceType is ServiceType.Ssh) 2022 else 51
         appSession.username = appsFilesystem.defaultUsername
         appSession.password = appsFilesystem.defaultPassword
         appSession.vncPassword = appsFilesystem.defaultVncPassword

--- a/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
@@ -157,7 +157,6 @@ class AppsStartupFsm(
         state.postValue(SyncingDatabaseEntries)
         appSession.filesystemId = appsFilesystem.id
         appSession.filesystemName = appsFilesystem.name
-        appSession.serviceType = appSession.serviceType
         appSession.port = if (appSession.serviceType is ServiceType.Ssh) 2022 else 51
         appSession.username = appsFilesystem.defaultUsername
         appSession.password = appsFilesystem.defaultPassword


### PR DESCRIPTION
## What changes does this PR introduce?
Fix launching VNC sessions/apps

## Any background context you want to provide?
We broke this in our last release and it is effecting many people.
Matthew will probably rework this and add tests, because he is a nice guy.

## Where should the reviewer start?
AppStartupFsm.kt

## Has this been manually tested? How?
Yes.  Checking launching a broken session and a new one and toggling the session type between launches.

## What value does this provide to our end users?
They can use graphical sessions again.

