### PR TITLE
Create end-to-end VNC session regression test.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -280,7 +280,6 @@ dependencies {
     def mockito_version = '2.23.0'
     def mockito_kotlin_version = '2.1.0'
     def core_testing_version = '2.0.0-beta01'
-    def espresso_version = '3.2.0'
     def androidx_test_version = '1.2.0'
     def androidx_test_ext_version = '1.1.0'
 
@@ -296,6 +295,7 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$androidx_test_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_test_ext_version"
     // Barista packages espresso-core and espresso-contrib
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
     androidTestImplementation('com.schibsted.spain:barista:3.1.0') {
         exclude group: 'com.android.support'
         exclude group: 'org.jetbrains.kotlin'

--- a/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
+++ b/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
@@ -18,9 +18,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.platform.app.InstrumentationRegistry
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
-import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import java.io.File
-import java.lang.Exception
 import java.util.concurrent.TimeoutException
 
 fun @receiver:IdRes Int.shortWaitForDisplay() {

--- a/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
+++ b/app/src/androidTest/java/tech/ula/androidTestHelpers/EspressoHelpers.kt
@@ -18,7 +18,9 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.platform.app.InstrumentationRegistry
 import android.view.KeyCharacterMap
 import android.view.KeyEvent
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import java.io.File
+import java.lang.Exception
 import java.util.concurrent.TimeoutException
 
 fun @receiver:IdRes Int.shortWaitForDisplay() {

--- a/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
@@ -4,16 +4,13 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import androidx.test.espresso.Espresso
-import androidx.test.espresso.base.DefaultFailureHandler
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers.*
+import androidx.test.espresso.intent.matcher.IntentMatchers.* // ktlint-disable no-wildcard-imports
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertDisplayedAtPosition
-import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogPositiveButton
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo

--- a/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/tech/ula/ui/MainActivityTest.kt
@@ -1,12 +1,19 @@
 package tech.ula.ui
 
 import android.Manifest
+import android.content.Intent
+import android.net.Uri
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.base.DefaultFailureHandler
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertDisplayedAtPosition
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
 import com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogPositiveButton
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
@@ -27,7 +34,7 @@ import java.io.File
 class MainActivityTest {
 
     @get:Rule
-    val activityRule = ActivityTestRule(MainActivity::class.java)
+    val intentTestRule = IntentsTestRule(MainActivity::class.java)
 
     // Permissions are granted automatically by firebase, so to keep parity we skip that step
     // locally as well.
@@ -47,12 +54,12 @@ class MainActivityTest {
 
     @Before
     fun setup() {
-        activity = activityRule.activity
+        activity = intentTestRule.activity
         homeDirectory = File(activity.filesDir, homeLocation)
     }
 
     @Test
-    fun testHappyPath() {
+    fun test_ssh_session_can_be_started() {
         R.id.app_list_fragment.shortWaitForDisplay()
 
         R.id.swipe_refresh.waitForRefresh(activity)
@@ -119,6 +126,58 @@ class MainActivityTest {
         clickListItem(R.id.list_apps, 0)
         assertNotDisplayed(R.id.layout_progress)
         R.id.terminal_view.shortWaitForDisplay()
+    }
+
+    @Test
+    fun test_vnc_session_can_be_started() {
+        R.id.app_list_fragment.shortWaitForDisplay()
+
+        R.id.swipe_refresh.waitForRefresh(activity)
+
+        // Click alpine
+        assertDisplayedAtPosition(R.id.list_apps, 0, R.id.apps_name, appName)
+        clickListItem(R.id.list_apps, 0)
+
+        // Set filesystem credentials
+        R.string.filesystem_credentials_reasoning.waitForDisplay()
+        writeTo(R.id.text_input_username, username)
+        writeTo(R.id.text_input_password, sshPassword)
+        writeTo(R.id.text_input_vnc_password, vncPassword)
+        clickDialogPositiveButton()
+
+        // Set session type to vnc
+        R.string.prompt_app_connection_type_preference.shortWaitForDisplay()
+        clickRadioButtonItem(R.id.radio_apps_service_type_preference, R.id.vnc_radio_button)
+        clickDialogPositiveButton()
+
+        // Wait for progress dialog to complete
+        R.id.progress_bar_session_list.shortWaitForDisplay()
+        R.string.progress_downloading.longWaitForDisplay()
+        R.string.progress_copying_downloads.extraLongWaitForDisplay()
+        R.string.progress_verifying_assets.waitForDisplay()
+        R.string.progress_setting_up_filesystem.waitForDisplay()
+        R.string.progress_starting.longWaitForDisplay()
+        Thread.sleep(10000)
+
+        val clientIntent = Intent()
+        clientIntent.action = Intent.ACTION_VIEW
+        clientIntent.type = "application/vnd.vnc"
+        clientIntent.data = Uri.parse("vnc://127.0.0.1:5951/?VncUsername=$username&VncPassword=$vncPassword")
+        clientIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        val packageManager = activity.packageManager
+        val activities = packageManager.queryIntentActivities(clientIntent, 0)
+        if (activities.size > 0) {
+            // Match case where bVNC is present, e.g. test is running on personal device
+            intended(hasAction(Intent.ACTION_VIEW))
+            intended(hasData(Uri.parse("vnc://127.0.0.1:5951/?VncUsername=$username&VncPassword=$vncPassword")))
+            intended(hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK))
+        } else {
+            // Match case where bVNC is not present on device, e.g. firebase
+            val packageName = "com.iiordanov.freebVNC"
+            intended(hasAction(Intent.ACTION_VIEW))
+            intended(hasData(Uri.parse("market://details?id=$packageName")))
+            intended(hasFlag(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
     }
 
     private fun doHappyPathTestScript(): List<File> {

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -5,9 +5,8 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.IBinder
-import android.util.Log
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import kotlinx.coroutines.*
+import kotlinx.coroutines.* // ktlint-disable no-wildcard-imports
 import tech.ula.model.entities.App
 import tech.ula.model.entities.ServiceType
 import tech.ula.model.repositories.UlaDatabase

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -155,7 +155,7 @@ class ServerService : Service(), CoroutineScope {
 
     private fun startSshClient(session: Session) {
         val connectBotIntent = Intent()
-        connectBotIntent.action = "android.intent.action.VIEW"
+        connectBotIntent.action = Intent.ACTION_VIEW
         connectBotIntent.data = Uri.parse("ssh://${session.username}@localhost:2022/#userland")
         connectBotIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
 
@@ -164,7 +164,7 @@ class ServerService : Service(), CoroutineScope {
 
     private fun startVncClient(session: Session, packageName: String) {
         val bVncIntent = Intent()
-        bVncIntent.action = "android.intent.action.VIEW"
+        bVncIntent.action = Intent.ACTION_VIEW
         bVncIntent.type = "application/vnd.vnc"
         bVncIntent.data = Uri.parse("vnc://127.0.0.1:5951/?VncUsername=${session.username}&VncPassword=${session.vncPassword}")
         bVncIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -5,18 +5,21 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.IBinder
+import android.util.Log
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import tech.ula.model.entities.App
 import tech.ula.model.entities.ServiceType
 import tech.ula.model.repositories.UlaDatabase
 import tech.ula.model.entities.Session
 import tech.ula.utils.* // ktlint-disable no-wildcard-imports
+import kotlin.coroutines.CoroutineContext
 
-class ServerService : Service() {
+class ServerService : Service(), CoroutineScope {
+
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Default + job
 
     companion object {
         const val SERVER_SERVICE_RESULT: String = "tech.ula.ServerService.RESULT"
@@ -53,9 +56,8 @@ class ServerService : Service() {
 
         when (intent?.getStringExtra("type")) {
             "start" -> {
-                val coroutineScope = CoroutineScope(Dispatchers.Default)
                 val session: Session = intent.getParcelableExtra("session")!!
-                coroutineScope.launch { startSession(session) }
+                this.launch { startSession(session) }
             }
             "stopApp" -> {
                 val app: App = intent.getParcelableExtra("app")!!
@@ -87,8 +89,16 @@ class ServerService : Service() {
     // to clean up when app is swiped away.
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        // Redundancy to ensure no hanging processes, given broad device spectrum.
+        this.coroutineContext.cancel()
         stopForeground(true)
         stopSelf()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Redundancy to ensure no hanging processes, given broad device spectrum.
+        this.coroutineContext.cancel()
     }
 
     private fun removeSession(session: Session) {
@@ -146,7 +156,7 @@ class ServerService : Service() {
     private fun startSshClient(session: Session) {
         val connectBotIntent = Intent()
         connectBotIntent.action = "android.intent.action.VIEW"
-        connectBotIntent.data = Uri.parse("ssh://${session.username}@localhost:${session.port}/#userland")
+        connectBotIntent.data = Uri.parse("ssh://${session.username}@localhost:2022/#userland")
         connectBotIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
 
         startActivity(connectBotIntent)

--- a/app/src/main/java/tech/ula/model/entities/Session.kt
+++ b/app/src/main/java/tech/ula/model/entities/Session.kt
@@ -77,7 +77,7 @@ data class Session(
     var password: String = "",
     var vncPassword: String = "",
     var serviceType: ServiceType = ServiceType.Unselected,
-    var port: Long = 2022,
+    var port: Long = 2022, // TODO This can be removed. Any eventual port managing should be done at a high     er abstraction.
     var pid: Long = 0,
     var geometry: String = "",
     val isAppsSession: Boolean = false

--- a/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
+++ b/app/src/main/java/tech/ula/model/state/AppsStartupFsm.kt
@@ -114,7 +114,6 @@ class AppsStartupFsm(
 
     private suspend fun setServiceType(appSession: Session, serviceType: ServiceType) = withContext(Dispatchers.IO) {
         appSession.serviceType = serviceType
-        appSession.port = if (serviceType == ServiceType.Ssh) 2022 else 51
         sessionDao.updateSession(appSession)
         state.postValue(AppHasServiceTypeSet)
     }
@@ -157,7 +156,6 @@ class AppsStartupFsm(
         state.postValue(SyncingDatabaseEntries)
         appSession.filesystemId = appsFilesystem.id
         appSession.filesystemName = appsFilesystem.name
-        appSession.port = if (appSession.serviceType is ServiceType.Ssh) 2022 else 51
         appSession.username = appsFilesystem.defaultUsername
         appSession.password = appsFilesystem.defaultPassword
         appSession.vncPassword = appsFilesystem.defaultVncPassword

--- a/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
+++ b/app/src/main/java/tech/ula/ui/SessionEditFragment.kt
@@ -153,7 +153,6 @@ class SessionEditFragment : Fragment() {
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 val selectedServiceType = parent?.getItemAtPosition(position).toString().toServiceType()
                 session.serviceType = selectedServiceType
-                session.port = getDefaultServicePort(selectedServiceType)
             }
         }
 

--- a/app/src/main/java/tech/ula/utils/LocalServerManager.kt
+++ b/app/src/main/java/tech/ula/utils/LocalServerManager.kt
@@ -10,6 +10,8 @@ class LocalServerManager(
     private val logger: Logger = SentryLogger()
 ) {
 
+    private val vncDisplayNumber = 51
+
     fun Process.pid(): Long {
         return this.toString()
                 .substringAfter("pid=")
@@ -18,35 +20,40 @@ class LocalServerManager(
                 .trim().toLong()
     }
 
-    private fun Session.pidRelativeFilePath(): String {
-        return when (this.serviceType) {
-            ServiceType.Ssh -> "/run/dropbear.pid"
-            ServiceType.Vnc -> "/home/${this.username}/.vnc/localhost:${this.port}.pid"
-            ServiceType.Xsdl -> "/tmp/xsdl.pidfile"
-            else -> "error"
-        }
-    }
-
-    private fun Session.pidFilePath(): String {
-        return "$applicationFilesDirPath/${this.filesystemId}${this.pidRelativeFilePath()}"
-    }
-
-    fun Session.pid(): Long {
-        val pidFile = File(this.pidFilePath())
-        if (!pidFile.exists()) return -1
-        return try {
-            pidFile.readText().trim().toLong()
-        } catch (e: Exception) {
-            -1
-        }
-    }
-
     fun startServer(session: Session): Long {
         return when (session.serviceType) {
             ServiceType.Ssh -> startSSHServer(session)
             ServiceType.Vnc -> startVNCServer(session)
             ServiceType.Xsdl -> setDisplayNumberAndStartTwm(session)
             else -> 0
+        }
+    }
+
+    fun stopService(session: Session) {
+        val command = "support/killProcTree.sh ${session.pid} ${session.serverPid()}"
+        val result = busyboxExecutor.executeScript(command)
+        if (result is FailedExecution) {
+            val details = "func: stopService err: ${result.reason}"
+            val breadcrumb = UlaBreadcrumb("LocalServerManager", BreadcrumbType.RuntimeError, details)
+            logger.addBreadcrumb(breadcrumb)
+        }
+    }
+
+    fun isServerRunning(session: Session): Boolean {
+        val command = "support/isServerInProcTree.sh ${session.serverPid()}"
+        // The server itself is run by a third-party, so we can consider this to always be true.
+        // The third-party app is responsible for handling errors starting their server.
+        if (session.serviceType == ServiceType.Xsdl) return true
+        val result = busyboxExecutor.executeScript(command)
+        return when (result) {
+            is SuccessfulExecution -> true
+            is FailedExecution -> {
+                val details = "func: isServerRunning err: ${result.reason}"
+                val breadcrumb = UlaBreadcrumb("LocalServerManager", BreadcrumbType.RuntimeError, details)
+                logger.addBreadcrumb(breadcrumb)
+                false
+            }
+            else -> false
         }
     }
 
@@ -123,31 +130,26 @@ class LocalServerManager(
         }
     }
 
-    fun stopService(session: Session) {
-        val command = "support/killProcTree.sh ${session.pid} ${session.pid()}"
-        val result = busyboxExecutor.executeScript(command)
-        if (result is FailedExecution) {
-            val details = "func: stopService err: ${result.reason}"
-            val breadcrumb = UlaBreadcrumb("LocalServerManager", BreadcrumbType.RuntimeError, details)
-            logger.addBreadcrumb(breadcrumb)
+    private fun Session.pidRelativeFilePath(): String {
+        return when (this.serviceType) {
+            ServiceType.Ssh -> "/run/dropbear.pid"
+            ServiceType.Vnc -> "/home/${this.username}/.vnc/localhost:$vncDisplayNumber.pid"
+            ServiceType.Xsdl -> "/tmp/xsdl.pidfile"
+            else -> "error"
         }
     }
 
-    fun isServerRunning(session: Session): Boolean {
-        val command = "support/isServerInProcTree.sh ${session.pid()}"
-        // The server itself is run by a third-party, so we can consider this to always be true.
-        // The third-party app is responsible for handling errors starting their server.
-        if (session.serviceType == ServiceType.Xsdl) return true
-        val result = busyboxExecutor.executeScript(command)
-        return when (result) {
-            is SuccessfulExecution -> true
-            is FailedExecution -> {
-                val details = "func: isServerRunning err: ${result.reason}"
-                val breadcrumb = UlaBreadcrumb("LocalServerManager", BreadcrumbType.RuntimeError, details)
-                logger.addBreadcrumb(breadcrumb)
-                false
-            }
-            else -> false
+    private fun Session.pidFilePath(): String {
+        return "$applicationFilesDirPath/${this.filesystemId}${this.pidRelativeFilePath()}"
+    }
+
+    private fun Session.serverPid(): Long {
+        val pidFile = File(this.pidFilePath())
+        if (!pidFile.exists()) return -1
+        return try {
+            pidFile.readText().trim().toLong()
+        } catch (e: Exception) {
+            -1
         }
     }
 }

--- a/app/src/main/java/tech/ula/viewmodel/AppDetailsViewModel.kt
+++ b/app/src/main/java/tech/ula/viewmodel/AppDetailsViewModel.kt
@@ -105,7 +105,6 @@ class AppDetailsViewModel(private val sessionDao: SessionDao, private val appDet
             if (appSession == null) return@launch
 
             appSession.serviceType = selectedServiceType
-            appSession.port = if (selectedServiceType == ServiceType.Vnc) 51 else 2022
             this.launch {
                 withContext(Dispatchers.IO) {
                     sessionDao.updateSession(appSession)

--- a/app/src/test/java/tech/ula/utils/LocalServerManagerTest.kt
+++ b/app/src/test/java/tech/ula/utils/LocalServerManagerTest.kt
@@ -42,7 +42,7 @@ class LocalServerManagerTest {
 
     private fun createVNCPidFile(session: Session) {
         val folder = tempFolder.newFolder(filesystemDirName, "home", session.username, ".vnc")
-        vncPidFile = File("${folder.path}/localhost:${session.port}.pid")
+        vncPidFile = File("${folder.path}/localhost:51.pid")
         vncPidFile.createNewFile()
     }
 


### PR DESCRIPTION
## What changes does this PR introduce?
- End-to-end VNC session regression test.
- Handles server connection numbers in an appropriate place.
- Kills potentially leaked coroutines on application death.

## Any background context you want to provide?
Several regressions have been caused around sessions not keep track appropriately of these numbers, which should never actually change.

## Where should the reviewer start?
`LocalServerManager.kt`

## Has this been manually tested? How?
Yes, by creating vnc sessions.

## What value does this provide to our end users?
Higher confidence in the app.

## What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/xUnOWzaV2OiXuVkfdB/giphy.gif)
