### PR TITLE
Fix new seccomp filtering issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ reference:
   android_config: &android_config
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-28-ndk
+      - image: circleci/android@sha256:fa7a00c75f4b28cc4f2a15a382fb76e830d62a77efd1a3f8549f7f5fdad4ca44
     environment:
       TERM: dumb
       # Limit JVM heap size to prevent exceeding container memory

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,7 +198,7 @@ ext.architectures = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
 ext.libDir = "$project.projectDir/src/main/jniLibs"
 
 task downloadAssets(type: Download) {
-    def assetVersion = "v1.0.1"
+    def assetVersion = "v1.0.3"
     def baseUrl = "https://github.com/CypherpunkArmory/UserLAnd-Assets-Support/releases/download/$assetVersion"
     for (arch in architectures) {
         src "$baseUrl/$arch-assets.zip"


### PR DESCRIPTION
## What changes does this PR introduce?
Change what version of the support assets we are fetching to get a new version of proot which solves two newly occurring seccomp filtering issues.

## Any background context you want to provide?
`waitpid` and `chdir` were being blocked on certain version of android

## Where should the reviewer start?
Well really all the changes are in proot

## Has this been manually tested? How?
We will actually need some help from users with effected devices to be sure things are fixed, but I have tested that this does not seem to break anything.

## What value does this provide to our end users?
Users with effected devices should actually be able to user UserLAnd now.

## What GIF best describes this PR or how it makes you feel?
![Block chdir, WTF was someone thinking](https://media.giphy.com/media/l1J3nvV8lJYA5THnG/giphy.gif)
