### PR TITLE
Better support for armhf devices running Android 8.0+ (#1064)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode vcode
-        versionName "2.6.3"
+        versionName "2.6.4"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
@@ -198,7 +198,7 @@ ext.architectures = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
 ext.libDir = "$project.projectDir/src/main/jniLibs"
 
 task downloadAssets(type: Download) {
-    def assetVersion = "v1.1.0"
+    def assetVersion = "v1.1.7"
     def baseUrl = "https://github.com/CypherpunkArmory/UserLAnd-Assets-Support/releases/download/$assetVersion"
     for (arch in architectures) {
         src "$baseUrl/$arch-assets.zip"
@@ -209,9 +209,7 @@ task downloadAssets(type: Download) {
 task fetchAssets(dependsOn: downloadAssets) {
     doLast {
         for (arch in architectures) {
-            delete {
-                "$buildDir/$arch"
-            }
+            delete "$buildDir/$arch"
             copy {
                 from zipTree("$buildDir/$arch-assets.zip")
                 into "$buildDir/$arch"


### PR DESCRIPTION
Fix crashes on many older devices upgrading to a newer version of Android.