### PR TITLE
New Debian and Kali images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode vcode
-        versionName "2.6.4"
+        versionName "2.6.5"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'


### PR DESCRIPTION
This version only rolls the version number so people will see if the broken VNC startup will work again.  This was specific to people with devices using the armhf Debian or Kali images and caused the VNC server to never start.  It would just say starting service.  The actually changes are to those two asset sets and not here.