### PR TITLE
New Debian and Kali images (#1075)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode vcode
-        versionName "2.6.4"
+        versionName "2.6.5"
         
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'


### PR DESCRIPTION
Roll version number so people know something has changed.  It is really the Debian and Kali assets that have changed, but this would be invisible to users.  This will fix VNC startup for Debian and Kali on devices that were using the armhf assets.