### PR TITLE
Ported ctrl-space workaround from latest termux.

### DIFF
--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxPreferences.java
@@ -47,6 +47,7 @@ final class TermuxPreferences {
     int mBellBehaviour = BELL_VIBRATE;
 
     boolean mBackIsEscape;
+    boolean mUseCtrlSpaceWorkaround;
     boolean mShowExtraKeys;
     
     /**
@@ -57,10 +58,10 @@ final class TermuxPreferences {
     }
 
     TermuxPreferences(Context context) {
+        home_path = context.getFilesDir().getAbsolutePath() + "/home";
+
         reloadFromProperties(context);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-
-        home_path = context.getFilesDir().getAbsolutePath() + "/home";
 
         float dipInPixels = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1, context.getResources().getDisplayMetrics());
 
@@ -171,6 +172,7 @@ final class TermuxPreferences {
         }
 
         mBackIsEscape = "escape".equals(props.getProperty("back-key", "back"));
+        mUseCtrlSpaceWorkaround = Boolean.parseBoolean(props.getProperty("ctrl-space-workaround"));
 
         shortcuts.clear();
         parseAction("shortcut.create-session", SHORTCUT_ACTION_CREATE_SESSION, props);

--- a/termux-app/terminal-term/src/main/java/com/termux/app/TermuxViewClient.java
+++ b/termux-app/terminal-term/src/main/java/com/termux/app/TermuxViewClient.java
@@ -49,6 +49,11 @@ public final class TermuxViewClient implements TerminalViewClient {
     }
 
     @Override
+    public boolean shouldUseCtrlSpaceWorkaround() {
+        return mActivity.mSettings.mUseCtrlSpaceWorkaround;
+    }
+
+    @Override
     public void copyModeChanged(boolean copyMode) {
         // Disable drawer while copying.
         mActivity.getDrawer().setDrawerLockMode(copyMode ? DrawerLayout.LOCK_MODE_LOCKED_CLOSED : DrawerLayout.LOCK_MODE_UNLOCKED);

--- a/termux-app/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/termux-app/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -571,6 +571,11 @@ public final class TerminalView extends View {
                         return onKeyUp(keyCode, event);
                 }
             }
+        } else if (mClient.shouldUseCtrlSpaceWorkaround() &&
+                   keyCode == KeyEvent.KEYCODE_SPACE && event.isCtrlPressed()) {
+            /* ctrl+space does not work on some ROMs without this workaround.
+               However, this breaks it on devices where it works out of the box. */
+            return onKeyDown(keyCode, event);
         }
         return super.onKeyPreIme(keyCode, event);
     }

--- a/termux-app/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
+++ b/termux-app/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
@@ -25,6 +25,8 @@ public interface TerminalViewClient {
 
     boolean shouldBackButtonBeMappedToEscape();
 
+    boolean shouldUseCtrlSpaceWorkaround();
+
     void copyModeChanged(boolean copyMode);
 
     boolean onKeyDown(int keyCode, KeyEvent e, TerminalSession session);


### PR DESCRIPTION
**Note**
Pull requests should follow the git flow described in the [wiki](https://github.com/CypherpunkArmory/UserLAnd/wiki/Git-flow).
To get git history clean and aid in more useful release notes, it is essential to use the `Squash and merge` option when
merging into 'master', and the `Create merge commit` option when merging into 'releases'.

## What changes does this PR introduce?

*  Currentry, UserLAnd terminal does not accept ctrl-space after android9. But the latest termux solved this problem. This PR ports the fix.
* specification
  * In /host-rootfs/data/data/tech.ula/files/home/.termux/termux.properteis, if the property "ctrl-space-workaround" is set true, the workaround is enabled.

## Any background context you want to provide?

I want to use emacs on UserLAnd terminal.

## Where should the reviewer start?

TerminalView.java
It contains the core of this fix.

## Has this been manually tested? How?

Yes, It works on my android 11 phone(pixel4a 5g).

## What value does this provide to our end users?

End users can use ctrl-space key bind on UserLAnd terminal.
Especially, emacs users needs ctrl-space.

## What GIF best describes this PR or how it makes you feel?
![](paste_url_in_here)
